### PR TITLE
feat: Repository wechseln (aktives Repo)

### DIFF
--- a/src/ghGPT.Api/Controllers/RepositoriesController.cs
+++ b/src/ghGPT.Api/Controllers/RepositoriesController.cs
@@ -13,6 +13,27 @@ public class RepositoriesController(IRepositoryService service, IHubContext<Repo
     [HttpGet]
     public ActionResult<IReadOnlyList<RepositoryInfo>> GetAll() => Ok(service.GetAll());
 
+    [HttpGet("active")]
+    public ActionResult<RepositoryInfo> GetActive()
+    {
+        var repo = service.GetActive();
+        return repo is not null ? Ok(repo) : NoContent();
+    }
+
+    [HttpPut("active/{id}")]
+    public ActionResult SetActive(string id)
+    {
+        try
+        {
+            service.SetActive(id);
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
     [HttpPost("create")]
     public async Task<ActionResult<RepositoryInfo>> Create([FromBody] CreateRepoRequest request)
     {

--- a/src/ghGPT.Core/Repositories/IRepositoryService.cs
+++ b/src/ghGPT.Core/Repositories/IRepositoryService.cs
@@ -3,6 +3,8 @@ namespace ghGPT.Core.Repositories;
 public interface IRepositoryService
 {
     IReadOnlyList<RepositoryInfo> GetAll();
+    RepositoryInfo? GetActive();
+    void SetActive(string id);
     Task<RepositoryInfo> CreateAsync(string localPath, string name);
     Task<RepositoryInfo> ImportAsync(string localPath);
     Task<RepositoryInfo> CloneAsync(string remoteUrl, string localPath, IProgress<string>? progress = null);

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -221,17 +221,28 @@ export class AppShell extends LitElement {
 
   private async loadRepos() {
     this.repos = await repositoryService.getAll();
-    if (!this.activeRepoId && this.repos.length > 0)
-      this.activeRepoId = this.repos[0].id;
+
+    const savedId = repositoryService.loadActiveId();
+    if (savedId && this.repos.some(r => r.id === savedId)) {
+      await this.activateRepo(savedId);
+    } else if (this.repos.length > 0) {
+      await this.activateRepo(this.repos[0].id);
+    }
+  }
+
+  private async activateRepo(id: string) {
+    this.activeRepoId = id;
+    repositoryService.saveActiveId(id);
+    await repositoryService.setActive(id).catch(() => {});
   }
 
   private get activeRepo(): RepositoryInfo | undefined {
     return this.repos.find(r => r.id === this.activeRepoId);
   }
 
-  private onRepoAdded(e: CustomEvent<RepositoryInfo>) {
+  private async onRepoAdded(e: CustomEvent<RepositoryInfo>) {
     this.repos = [...this.repos, e.detail];
-    this.activeRepoId = e.detail.id;
+    await this.activateRepo(e.detail.id);
   }
 
   render() {
@@ -250,7 +261,7 @@ export class AppShell extends LitElement {
 
           ${this.repos.map(repo => html`
             <div class="repo-item ${repo.id === this.activeRepoId ? 'active' : ''}"
-              @click=${() => this.activeRepoId = repo.id}>
+              @click=${() => this.activateRepo(repo.id)}>
               <span>📁</span>
               <span class="repo-name">${repo.name}</span>
               <span class="repo-branch">${repo.currentBranch}</span>

--- a/src/ghGPT.Frontend/src/services/repository-service.ts
+++ b/src/ghGPT.Frontend/src/services/repository-service.ts
@@ -8,12 +8,19 @@ export interface RepositoryInfo {
   currentBranch: string;
 }
 
+const ACTIVE_REPO_KEY = 'ghgpt:activeRepoId';
+
 export const repositoryService = {
   getAll: () => api.get<RepositoryInfo[]>('/repos'),
+  getActive: () => api.get<RepositoryInfo | null>('/repos/active'),
+  setActive: (id: string) => api.put<void>('/repos/active/' + id),
   create: (localPath: string, name: string) =>
     api.post<RepositoryInfo>('/repos/create', { localPath, name }),
   import: (localPath: string) =>
     api.post<RepositoryInfo>('/repos/import', { localPath }),
   clone: (remoteUrl: string, localPath: string) =>
     api.post<RepositoryInfo>('/repos/clone', { remoteUrl, localPath }),
+
+  saveActiveId: (id: string) => localStorage.setItem(ACTIVE_REPO_KEY, id),
+  loadActiveId: () => localStorage.getItem(ACTIVE_REPO_KEY),
 };

--- a/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
+++ b/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
@@ -6,8 +6,19 @@ namespace ghGPT.Infrastructure.Repositories;
 public class RepositoryService(IRepositoryStore store) : IRepositoryService
 {
     private readonly List<RepositoryInfo> _repos = [.. store.Load()];
+    private string? _activeRepoId;
 
     public IReadOnlyList<RepositoryInfo> GetAll() => _repos.AsReadOnly();
+
+    public RepositoryInfo? GetActive() =>
+        _activeRepoId is not null ? _repos.FirstOrDefault(r => r.Id == _activeRepoId) : null;
+
+    public void SetActive(string id)
+    {
+        if (_repos.All(r => r.Id != id))
+            throw new InvalidOperationException($"Repository '{id}' nicht gefunden.");
+        _activeRepoId = id;
+    }
 
     public Task<RepositoryInfo> CreateAsync(string localPath, string name)
     {


### PR DESCRIPTION
Closes #4

## Summary
- `GET /api/repos/active` gibt das aktuell aktive Repository zurück (204 wenn keins gesetzt)
- `PUT /api/repos/active/{id}` setzt das aktive Repository serverseitig (404 bei unbekannter ID)
- Klick auf ein Repository in der Sidebar aktiviert es und speichert die ID in `localStorage`
- Beim Start wird das zuletzt aktive Repository aus `localStorage` wiederhergestellt

## Test plan
- [x] Mehrere Repositories hinzufügen und zwischen ihnen wechseln → Sidebar hebt aktives Repo hervor
- [x] Seite neu laden → zuletzt aktives Repo wird wiederhergestellt
- [x] `GET /api/repos/active` gibt das aktive Repo zurück
- [x] `PUT /api/repos/active/{ungültige-id}` gibt 404 zurück