### PR TITLE
feat: add pull requests view for GitHub repositories

### DIFF
--- a/src/ghGPT.Api/Controllers/PullRequestsController.cs
+++ b/src/ghGPT.Api/Controllers/PullRequestsController.cs
@@ -1,0 +1,77 @@
+using ghGPT.Core.PullRequests;
+using ghGPT.Core.Repositories;
+using ghGPT.Infrastructure.PullRequests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ghGPT.Api.Controllers;
+
+[ApiController]
+[Route("api/repos/{id}/pull-requests")]
+public class PullRequestsController(
+    IRepositoryService repositoryService,
+    IPullRequestService pullRequestService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<PullRequestListItem>>> GetPullRequests(
+        string id,
+        [FromQuery] string state = "open")
+    {
+        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == id);
+        if (repo is null)
+            return NotFound(new { error = "Repository nicht gefunden." });
+
+        if (string.IsNullOrEmpty(repo.RemoteUrl))
+            return BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
+
+        (string owner, string repoName) ownerRepo;
+        try
+        {
+            ownerRepo = PullRequestService.ParseRemoteUrl(repo.RemoteUrl);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+
+        try
+        {
+            var prs = await pullRequestService.GetPullRequestsAsync(ownerRepo.owner, ownerRepo.repoName, state);
+            return Ok(prs);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{number:int}")]
+    public async Task<ActionResult<PullRequestDetail>> GetPullRequestDetail(string id, int number)
+    {
+        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == id);
+        if (repo is null)
+            return NotFound(new { error = "Repository nicht gefunden." });
+
+        if (string.IsNullOrEmpty(repo.RemoteUrl))
+            return BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
+
+        (string owner, string repoName) ownerRepo;
+        try
+        {
+            ownerRepo = PullRequestService.ParseRemoteUrl(repo.RemoteUrl);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+
+        try
+        {
+            var detail = await pullRequestService.GetPullRequestDetailAsync(ownerRepo.owner, ownerRepo.repoName, number);
+            return Ok(detail);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/src/ghGPT.Core/PullRequests/IPullRequestService.cs
+++ b/src/ghGPT.Core/PullRequests/IPullRequestService.cs
@@ -1,0 +1,7 @@
+namespace ghGPT.Core.PullRequests;
+
+public interface IPullRequestService
+{
+    Task<IReadOnlyList<PullRequestListItem>> GetPullRequestsAsync(string owner, string repo, string state = "open");
+    Task<PullRequestDetail> GetPullRequestDetailAsync(string owner, string repo, int number);
+}

--- a/src/ghGPT.Core/PullRequests/PullRequestDetail.cs
+++ b/src/ghGPT.Core/PullRequests/PullRequestDetail.cs
@@ -1,0 +1,22 @@
+namespace ghGPT.Core.PullRequests;
+
+public class PullRequestDetail
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public string AuthorLogin { get; init; } = string.Empty;
+    public string AuthorAvatarUrl { get; init; } = string.Empty;
+    public string HeadBranch { get; init; } = string.Empty;
+    public string BaseBranch { get; init; } = string.Empty;
+    public bool IsDraft { get; init; }
+    public string Body { get; init; } = string.Empty;
+    public IReadOnlyList<string> Labels { get; init; } = [];
+    public IReadOnlyList<PullRequestReview> Reviews { get; init; } = [];
+    public IReadOnlyList<PullRequestFile> Files { get; init; } = [];
+    public bool CiPassing { get; init; }
+    public bool CiHasCombinedStatus { get; init; }
+    public string HtmlUrl { get; init; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+}

--- a/src/ghGPT.Core/PullRequests/PullRequestFile.cs
+++ b/src/ghGPT.Core/PullRequests/PullRequestFile.cs
@@ -1,0 +1,10 @@
+namespace ghGPT.Core.PullRequests;
+
+public class PullRequestFile
+{
+    public string FileName { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public int Additions { get; init; }
+    public int Deletions { get; init; }
+    public int Changes { get; init; }
+}

--- a/src/ghGPT.Core/PullRequests/PullRequestListItem.cs
+++ b/src/ghGPT.Core/PullRequests/PullRequestListItem.cs
@@ -1,0 +1,18 @@
+namespace ghGPT.Core.PullRequests;
+
+public class PullRequestListItem
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public string AuthorLogin { get; init; } = string.Empty;
+    public string AuthorAvatarUrl { get; init; } = string.Empty;
+    public string HeadBranch { get; init; } = string.Empty;
+    public string BaseBranch { get; init; } = string.Empty;
+    public bool IsDraft { get; init; }
+    public string? MergeableState { get; init; }
+    public IReadOnlyList<string> Labels { get; init; } = [];
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string HtmlUrl { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Core/PullRequests/PullRequestReview.cs
+++ b/src/ghGPT.Core/PullRequests/PullRequestReview.cs
@@ -1,0 +1,9 @@
+namespace ghGPT.Core.PullRequests;
+
+public class PullRequestReview
+{
+    public string ReviewerLogin { get; init; } = string.Empty;
+    public string ReviewerAvatarUrl { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public DateTimeOffset SubmittedAt { get; init; }
+}

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -7,6 +7,7 @@ import './repo-dialog';
 import './changes-view';
 import './history-view';
 import './branches-view';
+import './pull-requests-view';
 
 type View = 'changes' | 'history' | 'branches' | 'pull-requests';
 
@@ -881,7 +882,7 @@ export class AppShell extends LitElement {
           <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('push')}>↑ Push</button>
         </div>
 
-        <div class="content ${this.activeView !== 'changes' && this.activeView !== 'branches' ? 'padded' : ''}">
+        <div class="content ${this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests' ? 'padded' : ''}">
           ${this.activeRepo ? this.renderView() : html`
             <div class="placeholder">
               <span class="placeholder-icon">📂</span>
@@ -985,7 +986,7 @@ export class AppShell extends LitElement {
       case 'branches':
         return html`<branches-view .repoId=${this.activeRepoId ?? ''} @branch-changed=${this.onBranchChanged}></branches-view>`;
       case 'pull-requests':
-        return html`<div class="placeholder"><span class="placeholder-icon">🔀</span><span>Keine Pull Requests</span></div>`;
+        return html`<pull-requests-view .repoId=${this.activeRepoId ?? ''}></pull-requests-view>`;
     }
   }
 }

--- a/src/ghGPT.Frontend/src/components/pull-requests-view.ts
+++ b/src/ghGPT.Frontend/src/components/pull-requests-view.ts
@@ -1,0 +1,692 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  repositoryService,
+  type PullRequestListItem,
+  type PullRequestDetail,
+} from '../services/repository-service';
+
+@customElement('pull-requests-view')
+export class PullRequestsView extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      height: 100%;
+      overflow: hidden;
+      background: #181825;
+      color: #cdd6f4;
+      border: 1px solid #313244;
+      border-radius: 10px;
+    }
+
+    .list-panel {
+      width: 380px;
+      min-width: 380px;
+      display: flex;
+      flex-direction: column;
+      border-right: 1px solid #313244;
+      background: #1e1e2e;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      padding: 0.85rem 1rem;
+      border-bottom: 1px solid #313244;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      flex-shrink: 0;
+      background: #1e1e2e;
+    }
+
+    .panel-title {
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: #eef1ff;
+    }
+
+    .filter-row {
+      display: flex;
+      gap: 0.4rem;
+      align-items: center;
+    }
+
+    .filter-btn {
+      padding: 0.2rem 0.65rem;
+      font-size: 0.75rem;
+      border: 1px solid #45475a;
+      border-radius: 4px;
+      background: transparent;
+      color: #a6adc8;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .filter-btn:hover {
+      background: #313244;
+      color: #cdd6f4;
+    }
+
+    .filter-btn.active {
+      background: #89b4fa;
+      border-color: #89b4fa;
+      color: #11111b;
+      font-weight: 600;
+    }
+
+    .refresh-btn {
+      margin-left: auto;
+      padding: 0.2rem 0.6rem;
+      font-size: 0.75rem;
+      border: 1px solid #45475a;
+      border-radius: 4px;
+      background: transparent;
+      color: #a6adc8;
+      cursor: pointer;
+    }
+
+    .refresh-btn:hover {
+      background: #313244;
+      color: #cdd6f4;
+    }
+
+    .list-scroll {
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    .pr-entry {
+      padding: 0.85rem 1rem;
+      border-bottom: 1px solid rgba(49, 50, 68, 0.8);
+      cursor: pointer;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .pr-entry:hover {
+      background: #25273a;
+    }
+
+    .pr-entry.selected {
+      background: #313244;
+    }
+
+    .pr-entry-top {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+
+    .pr-number {
+      font-size: 0.75rem;
+      color: #8f96b3;
+      white-space: nowrap;
+      flex-shrink: 0;
+      margin-top: 0.1rem;
+    }
+
+    .pr-title {
+      font-size: 0.87rem;
+      font-weight: 600;
+      color: #eef1ff;
+      line-height: 1.3;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+
+    .pr-entry-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.74rem;
+      color: #8f96b3;
+    }
+
+    .pr-branch {
+      font-family: monospace;
+      font-size: 0.72rem;
+      color: #89b4fa;
+    }
+
+    .pr-author {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .avatar-small {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    .avatar-fallback-small {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #89b4fa, #fab387);
+      color: #11111b;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.55rem;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    .badge {
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      font-size: 0.68rem;
+      font-weight: 600;
+    }
+
+    .badge-open {
+      background: rgba(166, 227, 161, 0.15);
+      color: #a6e3a1;
+      border: 1px solid rgba(166, 227, 161, 0.3);
+    }
+
+    .badge-closed {
+      background: rgba(243, 139, 168, 0.15);
+      color: #f38ba8;
+      border: 1px solid rgba(243, 139, 168, 0.3);
+    }
+
+    .badge-merged {
+      background: rgba(203, 166, 247, 0.15);
+      color: #cba6f7;
+      border: 1px solid rgba(203, 166, 247, 0.3);
+    }
+
+    .badge-draft {
+      background: rgba(166, 173, 200, 0.15);
+      color: #a6adc8;
+      border: 1px solid rgba(166, 173, 200, 0.3);
+    }
+
+    .badge-label {
+      background: rgba(137, 180, 250, 0.15);
+      color: #89b4fa;
+      border: 1px solid rgba(137, 180, 250, 0.3);
+    }
+
+    .detail-panel {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    .detail-header {
+      padding: 0.9rem 1rem;
+      border-bottom: 1px solid #313244;
+      background: #1e1e2e;
+      flex-shrink: 0;
+    }
+
+    .detail-header-top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .detail-title {
+      font-size: 1rem;
+      font-weight: 700;
+      color: #eef1ff;
+      line-height: 1.4;
+      flex: 1;
+    }
+
+    .open-github-btn {
+      padding: 0.3rem 0.75rem;
+      font-size: 0.78rem;
+      border: 1px solid #45475a;
+      border-radius: 6px;
+      background: transparent;
+      color: #89b4fa;
+      cursor: pointer;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .open-github-btn:hover {
+      background: rgba(137, 180, 250, 0.1);
+      border-color: #89b4fa;
+    }
+
+    .detail-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.78rem;
+      color: #a6adc8;
+    }
+
+    .branch-flow {
+      font-family: monospace;
+      font-size: 0.78rem;
+      color: #89b4fa;
+    }
+
+    .detail-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    .section-title {
+      font-size: 0.8rem;
+      font-weight: 700;
+      color: #a6adc8;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      margin-bottom: 0.5rem;
+    }
+
+    .pr-body {
+      font-size: 0.85rem;
+      color: #cdd6f4;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      font-family: inherit;
+      background: #181825;
+      padding: 0.75rem;
+      border-radius: 6px;
+      border: 1px solid #313244;
+      margin: 0;
+    }
+
+    .ci-indicator {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.78rem;
+    }
+
+    .ci-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .ci-dot.passing { background: #a6e3a1; }
+    .ci-dot.failing { background: #f38ba8; }
+    .ci-dot.none { background: #6c7086; }
+
+    .files-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .file-entry {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.4rem 0.6rem;
+      background: #181825;
+      border-radius: 4px;
+      font-size: 0.8rem;
+    }
+
+    .file-status {
+      font-size: 0.7rem;
+      font-weight: 700;
+      width: 18px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    .file-status-added { color: #a6e3a1; }
+    .file-status-removed { color: #f38ba8; }
+    .file-status-modified { color: #fab387; }
+    .file-status-renamed { color: #89b4fa; }
+
+    .file-name {
+      flex: 1;
+      color: #cdd6f4;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: monospace;
+    }
+
+    .file-stats {
+      font-size: 0.72rem;
+      color: #8f96b3;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .file-stat-add { color: #a6e3a1; }
+    .file-stat-del { color: #f38ba8; }
+
+    .reviews-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .review-entry {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.4rem 0.6rem;
+      background: #181825;
+      border-radius: 4px;
+      font-size: 0.8rem;
+    }
+
+    .review-avatar {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      object-fit: cover;
+      flex-shrink: 0;
+    }
+
+    .review-avatar-fallback {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #89b4fa, #fab387);
+      color: #11111b;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.65rem;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    .review-login { color: #cdd6f4; font-weight: 600; }
+
+    .review-state-approved { color: #a6e3a1; }
+    .review-state-changes { color: #f38ba8; }
+    .review-state-commented { color: #a6adc8; }
+
+    .placeholder-detail {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      color: #6c7086;
+      font-size: 0.9rem;
+    }
+
+    .placeholder-icon {
+      font-size: 2.5rem;
+    }
+
+    .loading, .error-msg, .empty-msg {
+      padding: 2rem 1rem;
+      text-align: center;
+      color: #6c7086;
+      font-size: 0.88rem;
+    }
+
+    .error-msg { color: #f38ba8; }
+  `;
+
+  @property() repoId = '';
+
+  @state() private prs: PullRequestListItem[] = [];
+  @state() private selectedPr: PullRequestDetail | null = null;
+  @state() private selectedNumber: number | null = null;
+  @state() private stateFilter: 'open' | 'closed' | 'all' = 'open';
+  @state() private loading = false;
+  @state() private loadingDetail = false;
+  @state() private error: string | null = null;
+  @state() private detailError: string | null = null;
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.repoId) this.loadPrs();
+  }
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has('repoId') && this.repoId) {
+      this.prs = [];
+      this.selectedPr = null;
+      this.selectedNumber = null;
+      this.error = null;
+      this.loadPrs();
+    }
+  }
+
+  private async loadPrs() {
+    this.loading = true;
+    this.error = null;
+    try {
+      this.prs = await repositoryService.getPullRequests(this.repoId, this.stateFilter);
+    } catch (e: unknown) {
+      this.error = e instanceof Error ? e.message : 'Fehler beim Laden der Pull Requests.';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async selectPr(number: number) {
+    this.selectedNumber = number;
+    this.selectedPr = null;
+    this.detailError = null;
+    this.loadingDetail = true;
+    try {
+      this.selectedPr = await repositoryService.getPullRequestDetail(this.repoId, number);
+    } catch (e: unknown) {
+      this.detailError = e instanceof Error ? e.message : 'Fehler beim Laden des PR-Details.';
+    } finally {
+      this.loadingDetail = false;
+    }
+  }
+
+  private async setFilter(filter: 'open' | 'closed' | 'all') {
+    if (this.stateFilter === filter) return;
+    this.stateFilter = filter;
+    this.selectedPr = null;
+    this.selectedNumber = null;
+    await this.loadPrs();
+  }
+
+  private renderStateBadge(state: string, isDraft: boolean) {
+    if (isDraft) return html`<span class="badge badge-draft">Draft</span>`;
+    if (state === 'merged') return html`<span class="badge badge-merged">Merged</span>`;
+    if (state === 'closed') return html`<span class="badge badge-closed">Closed</span>`;
+    return html`<span class="badge badge-open">Open</span>`;
+  }
+
+  private renderAvatar(avatarUrl: string, login: string, size: 'small' | 'medium' = 'small') {
+    if (size === 'small') {
+      return avatarUrl
+        ? html`<img class="avatar-small" src=${avatarUrl} alt=${login} />`
+        : html`<div class="avatar-fallback-small">${login.charAt(0).toUpperCase()}</div>`;
+    }
+    return avatarUrl
+      ? html`<img class="review-avatar" src=${avatarUrl} alt=${login} />`
+      : html`<div class="review-avatar-fallback">${login.charAt(0).toUpperCase()}</div>`;
+  }
+
+  private renderFileStatusClass(status: string) {
+    if (status === 'added') return 'file-status-added';
+    if (status === 'removed') return 'file-status-removed';
+    if (status === 'renamed') return 'file-status-renamed';
+    return 'file-status-modified';
+  }
+
+  private renderFileStatusChar(status: string) {
+    if (status === 'added') return 'A';
+    if (status === 'removed') return 'D';
+    if (status === 'renamed') return 'R';
+    return 'M';
+  }
+
+  private renderReviewStateClass(state: string) {
+    if (state === 'APPROVED') return 'review-state-approved';
+    if (state === 'CHANGES_REQUESTED') return 'review-state-changes';
+    return 'review-state-commented';
+  }
+
+  private renderReviewStateLabel(state: string) {
+    if (state === 'APPROVED') return 'Approved';
+    if (state === 'CHANGES_REQUESTED') return 'Changes requested';
+    return 'Commented';
+  }
+
+  render() {
+    return html`
+      <div class="list-panel">
+        <div class="panel-header">
+          <span class="panel-title">Pull Requests</span>
+          <div class="filter-row">
+            <button class="filter-btn ${this.stateFilter === 'open' ? 'active' : ''}"
+              @click=${() => this.setFilter('open')}>Open</button>
+            <button class="filter-btn ${this.stateFilter === 'closed' ? 'active' : ''}"
+              @click=${() => this.setFilter('closed')}>Closed</button>
+            <button class="filter-btn ${this.stateFilter === 'all' ? 'active' : ''}"
+              @click=${() => this.setFilter('all')}>All</button>
+            <button class="refresh-btn" @click=${() => this.loadPrs()} ?disabled=${this.loading}>
+              ↻ Aktualisieren
+            </button>
+          </div>
+        </div>
+
+        <div class="list-scroll">
+          ${this.loading
+            ? html`<div class="loading">Lade Pull Requests...</div>`
+            : this.error
+            ? html`<div class="error-msg">${this.error}</div>`
+            : this.prs.length === 0
+            ? html`<div class="empty-msg">Keine Pull Requests gefunden.</div>`
+            : this.prs.map(pr => html`
+              <div class="pr-entry ${this.selectedNumber === pr.number ? 'selected' : ''}"
+                @click=${() => this.selectPr(pr.number)}>
+                <div class="pr-entry-top">
+                  <span class="pr-number">#${pr.number}</span>
+                  <span class="pr-title">${pr.title}</span>
+                </div>
+                <div class="pr-entry-meta">
+                  ${this.renderStateBadge(pr.state, pr.isDraft)}
+                  <div class="pr-author">
+                    ${this.renderAvatar(pr.authorAvatarUrl, pr.authorLogin)}
+                    <span>${pr.authorLogin}</span>
+                  </div>
+                  <span class="pr-branch">${pr.headBranch} → ${pr.baseBranch}</span>
+                  ${pr.labels.map(l => html`<span class="badge badge-label">${l}</span>`)}
+                </div>
+              </div>
+            `)}
+        </div>
+      </div>
+
+      <div class="detail-panel">
+        ${this.selectedNumber === null
+          ? html`
+            <div class="placeholder-detail">
+              <span class="placeholder-icon">🔀</span>
+              <span>Pull Request auswählen</span>
+            </div>
+          `
+          : this.loadingDetail
+          ? html`<div class="loading">Lade Details...</div>`
+          : this.detailError
+          ? html`<div class="error-msg">${this.detailError}</div>`
+          : this.selectedPr
+          ? html`
+            <div class="detail-header">
+              <div class="detail-header-top">
+                <div class="detail-title">#${this.selectedPr.number} ${this.selectedPr.title}</div>
+                <button class="open-github-btn"
+                  @click=${() => window.open(this.selectedPr!.htmlUrl, '_blank')}>
+                  Auf GitHub öffnen ↗
+                </button>
+              </div>
+              <div class="detail-meta">
+                ${this.renderStateBadge(this.selectedPr.state, this.selectedPr.isDraft)}
+                <div class="pr-author">
+                  ${this.renderAvatar(this.selectedPr.authorAvatarUrl, this.selectedPr.authorLogin)}
+                  <span>${this.selectedPr.authorLogin}</span>
+                </div>
+                <span class="branch-flow">${this.selectedPr.headBranch} → ${this.selectedPr.baseBranch}</span>
+                ${this.selectedPr.labels.map(l => html`<span class="badge badge-label">${l}</span>`)}
+                ${this.selectedPr.ciHasCombinedStatus ? html`
+                  <div class="ci-indicator">
+                    <div class="ci-dot ${this.selectedPr.ciPassing ? 'passing' : 'failing'}"></div>
+                    <span>CI ${this.selectedPr.ciPassing ? 'bestanden' : 'fehlgeschlagen'}</span>
+                  </div>
+                ` : ''}
+              </div>
+            </div>
+
+            <div class="detail-scroll">
+              ${this.selectedPr.body ? html`
+                <div>
+                  <div class="section-title">Beschreibung</div>
+                  <pre class="pr-body">${this.selectedPr.body}</pre>
+                </div>
+              ` : ''}
+
+              ${this.selectedPr.files.length > 0 ? html`
+                <div>
+                  <div class="section-title">Geänderte Dateien (${this.selectedPr.files.length})</div>
+                  <div class="files-list">
+                    ${this.selectedPr.files.map(f => html`
+                      <div class="file-entry">
+                        <span class="file-status ${this.renderFileStatusClass(f.status)}">
+                          ${this.renderFileStatusChar(f.status)}
+                        </span>
+                        <span class="file-name">${f.fileName}</span>
+                        <span class="file-stats">
+                          <span class="file-stat-add">+${f.additions}</span>
+                          <span> / </span>
+                          <span class="file-stat-del">-${f.deletions}</span>
+                        </span>
+                      </div>
+                    `)}
+                  </div>
+                </div>
+              ` : ''}
+
+              ${this.selectedPr.reviews.length > 0 ? html`
+                <div>
+                  <div class="section-title">Reviews (${this.selectedPr.reviews.length})</div>
+                  <div class="reviews-list">
+                    ${this.selectedPr.reviews.map(r => html`
+                      <div class="review-entry">
+                        ${this.renderAvatar(r.reviewerAvatarUrl, r.reviewerLogin, 'medium')}
+                        <span class="review-login">${r.reviewerLogin}</span>
+                        <span class="${this.renderReviewStateClass(r.state)}">
+                          ${this.renderReviewStateLabel(r.state)}
+                        </span>
+                      </div>
+                    `)}
+                  </div>
+                </div>
+              ` : ''}
+            </div>
+          `
+          : ''
+        }
+      </div>
+    `;
+  }
+}

--- a/src/ghGPT.Frontend/src/services/repository-service.ts
+++ b/src/ghGPT.Frontend/src/services/repository-service.ts
@@ -87,6 +87,57 @@ export interface AccountInfo {
   avatarUrl: string;
 }
 
+export interface PullRequestListItem {
+  number: number;
+  title: string;
+  state: string;
+  authorLogin: string;
+  authorAvatarUrl: string;
+  headBranch: string;
+  baseBranch: string;
+  isDraft: boolean;
+  mergeableState: string | null;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  htmlUrl: string;
+}
+
+export interface PullRequestReview {
+  reviewerLogin: string;
+  reviewerAvatarUrl: string;
+  state: string;
+  submittedAt: string;
+}
+
+export interface PullRequestFile {
+  fileName: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+}
+
+export interface PullRequestDetail {
+  number: number;
+  title: string;
+  state: string;
+  authorLogin: string;
+  authorAvatarUrl: string;
+  headBranch: string;
+  baseBranch: string;
+  isDraft: boolean;
+  body: string;
+  labels: string[];
+  reviews: PullRequestReview[];
+  files: PullRequestFile[];
+  ciPassing: boolean;
+  ciHasCombinedStatus: boolean;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export const repositoryService = {
   getAll: () => api.get<RepositoryInfo[]>('/repos'),
   getActive: () => api.get<RepositoryInfo | null>('/repos/active'),
@@ -134,6 +185,11 @@ export const repositoryService = {
     api.post<BranchInfo>(`/repos/${id}/branches`, { name, startPoint }),
   deleteBranch: (id: string, name: string) =>
     api.delete<void>(`/repos/${id}/branches/${encodeURIComponent(name)}`),
+
+  getPullRequests: (id: string, state: 'open' | 'closed' | 'all' = 'open') =>
+    api.get<PullRequestListItem[]>(`/repos/${id}/pull-requests?state=${state}`),
+  getPullRequestDetail: (id: string, number: number) =>
+    api.get<PullRequestDetail>(`/repos/${id}/pull-requests/${number}`),
 
   saveActiveId: (id: string) => localStorage.setItem(ACTIVE_REPO_KEY, id),
   loadActiveId: () => localStorage.getItem(ACTIVE_REPO_KEY),

--- a/src/ghGPT.Infrastructure/DependencyInjection.cs
+++ b/src/ghGPT.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,8 @@
 using ghGPT.Core.Account;
+using ghGPT.Core.PullRequests;
 using ghGPT.Core.Repositories;
 using ghGPT.Infrastructure.Account;
+using ghGPT.Infrastructure.PullRequests;
 using ghGPT.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using System.Runtime.InteropServices;
@@ -21,6 +23,7 @@ public static class DependencyInjection
         services.AddSingleton<IRepositoryStore, RepositoryStore>();
         services.AddSingleton<IRepositoryService, RepositoryService>();
         services.AddSingleton<IAccountService, AccountService>();
+        services.AddSingleton<IPullRequestService, PullRequestService>();
         return services;
     }
 }

--- a/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
+++ b/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
@@ -1,0 +1,156 @@
+using ghGPT.Core.PullRequests;
+using ghGPT.Infrastructure.Account;
+using Octokit;
+using System.Text.RegularExpressions;
+
+namespace ghGPT.Infrastructure.PullRequests;
+
+public class PullRequestService(ITokenStore tokenStore) : IPullRequestService
+{
+    private const string GitHubProductHeader = "ghGPT";
+
+    public async Task<IReadOnlyList<PullRequestListItem>> GetPullRequestsAsync(
+        string owner, string repo, string state = "open")
+    {
+        var client = CreateClient();
+
+        var prState = state switch
+        {
+            "closed" => ItemStateFilter.Closed,
+            "all" => ItemStateFilter.All,
+            _ => ItemStateFilter.Open
+        };
+
+        try
+        {
+            var prs = await client.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest
+            {
+                State = prState
+            }, new ApiOptions { PageSize = 100 });
+
+            return prs.Select(pr => new PullRequestListItem
+            {
+                Number = pr.Number,
+                Title = pr.Title,
+                State = pr.Merged ? "merged" : pr.State.StringValue,
+                AuthorLogin = pr.User?.Login ?? string.Empty,
+                AuthorAvatarUrl = pr.User?.AvatarUrl ?? string.Empty,
+                HeadBranch = pr.Head?.Ref ?? string.Empty,
+                BaseBranch = pr.Base?.Ref ?? string.Empty,
+                IsDraft = pr.Draft,
+                MergeableState = pr.MergeableState?.StringValue,
+                Labels = pr.Labels?.Select(l => l.Name).ToList() ?? [],
+                CreatedAt = pr.CreatedAt,
+                UpdatedAt = pr.UpdatedAt,
+                HtmlUrl = pr.HtmlUrl
+            }).ToList();
+        }
+        catch (AuthorizationException)
+        {
+            throw new InvalidOperationException("Kein gültiger GitHub-Account verbunden.");
+        }
+        catch (NotFoundException)
+        {
+            throw new InvalidOperationException("Repository nicht gefunden oder kein Zugriff.");
+        }
+        catch (RateLimitExceededException)
+        {
+            throw new InvalidOperationException("GitHub API Rate Limit erreicht. Bitte später erneut versuchen.");
+        }
+    }
+
+    public async Task<PullRequestDetail> GetPullRequestDetailAsync(string owner, string repo, int number)
+    {
+        var client = CreateClient();
+
+        try
+        {
+            var pr = await client.PullRequest.Get(owner, repo, number);
+
+            var reviewsTask = client.PullRequest.Review.GetAll(owner, repo, number);
+            var filesTask = client.PullRequest.Files(owner, repo, number);
+            var statusTask = client.Repository.Status.GetCombined(owner, repo, pr.Head.Sha);
+
+            await Task.WhenAll(reviewsTask, filesTask, statusTask);
+
+            var reviews = reviewsTask.Result
+                .Where(r => r.State != PullRequestReviewState.Pending)
+                .Select(r => new Core.PullRequests.PullRequestReview
+                {
+                    ReviewerLogin = r.User?.Login ?? string.Empty,
+                    ReviewerAvatarUrl = r.User?.AvatarUrl ?? string.Empty,
+                    State = r.State.StringValue,
+                    SubmittedAt = r.SubmittedAt
+                }).ToList();
+
+            var files = filesTask.Result
+                .Select(f => new Core.PullRequests.PullRequestFile
+                {
+                    FileName = f.FileName,
+                    Status = f.Status,
+                    Additions = f.Additions,
+                    Deletions = f.Deletions,
+                    Changes = f.Changes
+                }).ToList();
+
+            var combinedStatus = statusTask.Result;
+            var ciPassing = combinedStatus.TotalCount > 0 && combinedStatus.State == CommitState.Success;
+            var ciHasCombinedStatus = combinedStatus.TotalCount > 0;
+
+            return new PullRequestDetail
+            {
+                Number = pr.Number,
+                Title = pr.Title,
+                State = pr.Merged ? "merged" : pr.State.StringValue,
+                AuthorLogin = pr.User?.Login ?? string.Empty,
+                AuthorAvatarUrl = pr.User?.AvatarUrl ?? string.Empty,
+                HeadBranch = pr.Head?.Ref ?? string.Empty,
+                BaseBranch = pr.Base?.Ref ?? string.Empty,
+                IsDraft = pr.Draft,
+                Body = pr.Body ?? string.Empty,
+                Labels = pr.Labels?.Select(l => l.Name).ToList() ?? [],
+                Reviews = reviews,
+                Files = files,
+                CiPassing = ciPassing,
+                CiHasCombinedStatus = ciHasCombinedStatus,
+                HtmlUrl = pr.HtmlUrl,
+                CreatedAt = pr.CreatedAt,
+                UpdatedAt = pr.UpdatedAt
+            };
+        }
+        catch (AuthorizationException)
+        {
+            throw new InvalidOperationException("Kein gültiger GitHub-Account verbunden.");
+        }
+        catch (NotFoundException)
+        {
+            throw new InvalidOperationException("Pull Request nicht gefunden oder kein Zugriff.");
+        }
+        catch (RateLimitExceededException)
+        {
+            throw new InvalidOperationException("GitHub API Rate Limit erreicht. Bitte später erneut versuchen.");
+        }
+    }
+
+    private GitHubClient CreateClient()
+    {
+        var token = tokenStore.Load()
+            ?? throw new InvalidOperationException("Kein GitHub-Account verbunden. Bitte erst einen PAT-Token hinterlegen.");
+
+        return new GitHubClient(new ProductHeaderValue(GitHubProductHeader))
+        {
+            Credentials = new Credentials(token)
+        };
+    }
+
+    public static (string Owner, string Repo) ParseRemoteUrl(string remoteUrl)
+    {
+        var match = Regex.Match(remoteUrl,
+            @"(?:https://github\.com/|git@github\.com:)([^/]+)/([^/\.]+?)(?:\.git)?$");
+
+        if (!match.Success)
+            throw new InvalidOperationException("Dieses Repository ist kein GitHub-Repository.");
+
+        return (match.Groups[1].Value, match.Groups[2].Value);
+    }
+}


### PR DESCRIPTION
Implements issue #11. Adds GET /api/repos/{id}/pull-requests and GET /api/repos/{id}/pull-requests/{number} endpoints via Octokit, with a split-panel frontend component showing PR list, details, changed files, reviews and CI status.