### PR TITLE
fix: CurrentBranch beim App-Start aus git lesen (#36 followup)

### DIFF
--- a/src/ghGPT.Infrastructure/Repositories/RepositoryWatcherService.cs
+++ b/src/ghGPT.Infrastructure/Repositories/RepositoryWatcherService.cs
@@ -19,6 +19,7 @@ public class RepositoryWatcherService(
         var repos = store.Load();
         foreach (var repo in repos)
         {
+            repositoryService.RefreshCurrentBranch(repo.Id);
             StartWatcher(repo);
         }
 

--- a/tests/ghGPT.Infrastructure.Tests/RepositoryWatcherServiceTests.cs
+++ b/tests/ghGPT.Infrastructure.Tests/RepositoryWatcherServiceTests.cs
@@ -37,6 +37,32 @@ public class RepositoryWatcherServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task OnStartup_RefreshesCurrentBranchForAllRepos()
+    {
+        var path = CreateGitRepo("startup-repo");
+        Run("git checkout -b feature", path);
+
+        var repoId = "startup-id";
+        var info = new RepositoryInfo { Id = repoId, Name = "repo", LocalPath = path, CurrentBranch = "master" };
+
+        var store = Substitute.For<IRepositoryStore>();
+        store.Load().Returns([info]);
+
+        var repositoryService = Substitute.For<IRepositoryService>();
+        var notifier = Substitute.For<IRepositoryEventNotifier>();
+
+        var sut = new RepositoryWatcherService(store, repositoryService, notifier,
+            NullLogger<RepositoryWatcherService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        repositoryService.Received(1).RefreshCurrentBranch(repoId);
+
+        await sut.StopAsync(CancellationToken.None);
+        sut.Dispose();
+    }
+
+    [Fact]
     public async Task OnExternalBranchChange_RefreshesCurrentBranchBeforeNotifying()
     {
         var path = CreateGitRepo("watcher-repo");
@@ -72,7 +98,8 @@ public class RepositoryWatcherServiceTests : IDisposable
         repositoryService.Received().RefreshCurrentBranch(repoId);
         await notifier.Received().NotifyBranchChangedAsync(repoId);
 
-        Assert.Equal(["refresh", "notify"], callOrder);
+        // "refresh" tritt zweimal auf: einmal beim Start, einmal beim externen Branch-Wechsel
+        Assert.Equal(["refresh", "refresh", "notify"], callOrder);
 
         await sut.StopAsync(CancellationToken.None);
         sut.Dispose();


### PR DESCRIPTION
## Summary

Der erste PR (#39) hat nur externe Branch-Änderungen während der Laufzeit abgedeckt. Beim App-Start wurde `CurrentBranch` weiterhin direkt aus dem (potenziell veralteten) Store geladen.

- `RepositoryWatcherService.ExecuteAsync` ruft jetzt beim Start `RefreshCurrentBranch` für alle Repos auf, bevor der FileSystemWatcher gestartet wird

Closes #36

## Test plan

- [x] App neu starten → Toolbar zeigt den tatsächlich ausgecheckten Branch
- [x] `RepositoryWatcherServiceTests.OnStartup_RefreshesCurrentBranchForAllRepos` grün
- [x] `RepositoryWatcherServiceTests.OnExternalBranchChange_RefreshesCurrentBranchBeforeNotifying` grün