### PR TITLE
feat: show pull and push toolbar indicators

### DIFF
--- a/src/ghGPT.Frontend/e2e/git-toolbar-operations.spec.ts
+++ b/src/ghGPT.Frontend/e2e/git-toolbar-operations.spec.ts
@@ -60,7 +60,7 @@ test.afterEach(async () => {
   scenario = null;
 });
 
-test('fetch updates behind indicator in branch dropdown', async ({ page }) => {
+test('fetch updates behind indicator in branch dropdown and pull button', async ({ page }) => {
   const current = scenario!;
 
   fs.writeFileSync(path.join(current.peerDir, 'README.md'), '# Remote change from peer\n');
@@ -77,6 +77,7 @@ test('fetch updates behind indicator in branch dropdown', async ({ page }) => {
   }).toContain('behind 1');
 
   await expect(page.locator('.git-overlay')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Pull/i })).toContainText('↓1');
   await page.locator('.toolbar-branch').click();
   await expect(page.locator('.branch-dropdown-item.active .branch-dropdown-behind')).toContainText('↓1');
 });
@@ -105,6 +106,7 @@ test('push uploads a local commit to the remote', async ({ page }) => {
   execSync('git commit -m "local push change"', { cwd: current.localDir });
 
   await gotoRepo(page, current);
+  await expect(page.getByRole('button', { name: /Push/i })).toContainText('↑1');
   await page.getByRole('button', { name: /Push/i }).click();
 
   await expect.poll(() => {

--- a/src/ghGPT.Frontend/e2e/screenshots.spec.ts
+++ b/src/ghGPT.Frontend/e2e/screenshots.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { execSync } from 'child_process';
-import { createTempRepo, createTempRepoWithRemote, modifyFile, removeTempRepo, importRepo, setActiveRepo, deleteRepo, unstageAll } from './helpers';
+import { createTempRepo, createTempRepoWithRemote, createTempRepoWithRemotePeer, modifyFile, removeTempRepo, importRepo, setActiveRepo, deleteRepo, unstageAll } from './helpers';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -173,6 +173,11 @@ test('12 - Branches View: Hover auf Branch-Zeile', async ({ page }) => {
 let remoteLocalDir = '';
 let remoteRepoDir = '';
 let remoteRepoId = '';
+let pullLocalDir = '';
+let pullRemoteDir = '';
+let pullPeerDir = '';
+let pullDefaultBranch = '';
+let pullRepoId = '';
 
 test.beforeAll(async () => {
   ({ localDir: remoteLocalDir, remoteDir: remoteRepoDir } = createTempRepoWithRemote());
@@ -184,6 +189,24 @@ test.afterAll(async () => {
   await deleteRepo(remoteRepoId);
   removeTempRepo(remoteLocalDir);
   removeTempRepo(remoteRepoDir);
+});
+
+test.beforeAll(async () => {
+  ({
+    localDir: pullLocalDir,
+    remoteDir: pullRemoteDir,
+    peerDir: pullPeerDir,
+    defaultBranch: pullDefaultBranch,
+  } = createTempRepoWithRemotePeer());
+  const repo = await importRepo(pullLocalDir);
+  pullRepoId = repo.id;
+});
+
+test.afterAll(async () => {
+  await deleteRepo(pullRepoId);
+  removeTempRepo(pullLocalDir);
+  removeTempRepo(pullPeerDir);
+  removeTempRepo(pullRemoteDir);
 });
 
 test('13 - Branches View: Übersicht mit Remote-Branches', async ({ page }) => {
@@ -276,4 +299,37 @@ test('17 - Changes View: Partial Staging - Nach dem Stagen', async ({ page }) =>
   await expect(lineChecks.nth(1)).toBeChecked({ timeout: 5000 });
 
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '17-partial-staging-after-stage.png'), fullPage: true });
+});
+
+test('18 - Toolbar: Pull-Button mit Rueckstand', async ({ page }) => {
+  fs.writeFileSync(path.join(pullPeerDir, 'README.md'), '# Remote screenshot change\n');
+  execSync('git add README.md', { cwd: pullPeerDir });
+  execSync('git commit -m "peer screenshot change"', { cwd: pullPeerDir });
+  execSync(`git push origin ${pullDefaultBranch}`, { cwd: pullPeerDir });
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), pullRepoId);
+  await setActiveRepo(pullRepoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.getByRole('button', { name: /Fetch/i }).click();
+  await expect(page.locator('.git-overlay')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Pull/i })).toContainText('↓1');
+
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '18-toolbar-pull-behind.png'), fullPage: true });
+});
+
+test('19 - Toolbar: Push-Button mit Vorsprung', async ({ page }) => {
+  fs.writeFileSync(path.join(pullLocalDir, 'README.md'), '# Local screenshot change\n');
+  execSync('git add README.md', { cwd: pullLocalDir });
+  execSync('git commit -m "local screenshot change"', { cwd: pullLocalDir });
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), pullRepoId);
+  await setActiveRepo(pullRepoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await expect(page.getByRole('button', { name: /Push/i })).toContainText('↑1');
+
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '19-toolbar-push-ahead.png'), fullPage: true });
 });

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -680,6 +680,7 @@ export class AppShell extends LitElement {
     this.activeRepoId = id;
     repositoryService.saveActiveId(id);
     await repositoryService.setActive(id).catch(() => {});
+    this.branches = await repositoryService.getBranches(id).catch(() => []);
   }
 
   private get activeRepo(): RepositoryInfo | undefined {
@@ -791,6 +792,10 @@ export class AppShell extends LitElement {
     }
   }
 
+  private get headBranch(): BranchInfo | undefined {
+    return this.branches.find(branch => branch.isHead && !branch.isRemote);
+  }
+
   private renderAheadBehind(branch: BranchInfo) {
     if (!branch.trackingBranch) return null;
 
@@ -805,6 +810,26 @@ export class AppShell extends LitElement {
     return parts.length > 0
       ? html`<span class="branch-dropdown-ahead-behind">${parts}</span>`
       : null;
+  }
+
+  private renderPullButtonLabel() {
+    const headBranch = this.headBranch;
+    const showBehindCount = !!headBranch?.trackingBranch && headBranch.behindBy > 0;
+
+    return html`
+      <span>↓ Pull</span>
+      ${showBehindCount ? html` <span>↓${headBranch.behindBy}</span>` : ''}
+    `;
+  }
+
+  private renderPushButtonLabel() {
+    const headBranch = this.headBranch;
+    const showAheadCount = !!headBranch?.trackingBranch && headBranch.aheadBy > 0;
+
+    return html`
+      <span>↑ Push</span>
+      ${showAheadCount ? html` <span>↑${headBranch.aheadBy}</span>` : ''}
+    `;
   }
 
   render() {
@@ -905,8 +930,8 @@ export class AppShell extends LitElement {
           </div>
           <div class="toolbar-spacer"></div>
           <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('fetch')}>↓ Fetch</button>
-          <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('pull')}>↓ Pull</button>
-          <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('push')}>↑ Push</button>
+          <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('pull')}>${this.renderPullButtonLabel()}</button>
+          <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('push')}>${this.renderPushButtonLabel()}</button>
         </div>
 
         <div class="content ${this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests' ? 'padded' : ''}">


### PR DESCRIPTION
Closes #35.

Shows behind count in the Pull button and ahead count in the Push button, loads branch state on repo activation, and extends E2E toolbar coverage.

Tests:
- npm.cmd run test:e2e -- git-toolbar-operations.spec.ts
- npm.cmd run test:e2e -- screenshots.spec.ts -g Toolbar:

Follow-up bug tracked in #45.