### PR TITLE
fix: PAT-Authentifizierung für git push/pull/fetch (#45)

### DIFF
--- a/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
+++ b/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
@@ -564,14 +564,11 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
         };
     }
 
-    private string BuildAuthenticatedArguments(string arguments, string localPath, IProgress<string>? progress)
+    private string BuildAuthenticatedArguments(string arguments, string localPath)
     {
         var token = tokenStore.Load();
         if (token is null)
-        {
-            progress?.Report("[Auth] Kein Token gefunden – nicht angemeldet?");
             return arguments;
-        }
 
         string? remoteUrl;
         try
@@ -579,26 +576,15 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
             using var repo = new LibGit2Sharp.Repository(localPath);
             remoteUrl = repo.Network.Remotes["origin"]?.Url;
         }
-        catch (Exception ex)
+        catch
         {
-            progress?.Report($"[Auth] Remote-URL konnte nicht gelesen werden: {ex.Message}");
             return arguments;
         }
 
-        if (remoteUrl is null)
-        {
-            progress?.Report("[Auth] Kein origin-Remote konfiguriert.");
+        if (remoteUrl is null || !remoteUrl.StartsWith("https://github.com", StringComparison.OrdinalIgnoreCase))
             return arguments;
-        }
-
-        if (!remoteUrl.StartsWith("https://github.com", StringComparison.OrdinalIgnoreCase))
-        {
-            progress?.Report($"[Auth] Remote-URL ist kein HTTPS-GitHub-Remote: {remoteUrl}");
-            return arguments;
-        }
 
         var authenticatedUrl = remoteUrl.Replace("https://github.com/", $"https://oauth2:{token}@github.com/", StringComparison.OrdinalIgnoreCase);
-        progress?.Report($"[Auth] Token injiziert (Token-Länge: {token.Length})");
 
         var parts = arguments.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
         return parts.Length == 1
@@ -615,7 +601,7 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
         var info = GetRepoById(id);
         progress?.Report($"> git {arguments}");
 
-        var psi = new ProcessStartInfo("git", BuildAuthenticatedArguments(arguments, info.LocalPath, progress))
+        var psi = new ProcessStartInfo("git", BuildAuthenticatedArguments(arguments, info.LocalPath))
         {
             WorkingDirectory = info.LocalPath,
             RedirectStandardOutput = true,
@@ -691,6 +677,12 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
             line.Contains("Automatic merge failed", StringComparison.OrdinalIgnoreCase));
         if (mergeConflict is not null)
             return $"Merge-Konflikt beim Aktualisieren des Branches. {mergeConflict}";
+
+        var lines = outputLines.ToList();
+        var has403 = lines.Any(line => line.Contains("error: 403", StringComparison.OrdinalIgnoreCase) || line.Contains("returned error: 403", StringComparison.OrdinalIgnoreCase));
+        var hasPermissionDenied = lines.Any(line => line.Contains("Permission to", StringComparison.OrdinalIgnoreCase) && line.Contains("denied", StringComparison.OrdinalIgnoreCase));
+        if (has403 || hasPermissionDenied)
+            return "Push fehlgeschlagen (403): Der hinterlegte GitHub-Token hat keine Schreibberechtigung. Bitte stelle sicher, dass der PAT die Berechtigung 'Contents: Write' (Fine-grained) bzw. den Scope 'repo' (Classic) besitzt.";
 
         var authError = relevantLines.FirstOrDefault(line =>
             line.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
## Summary

- Der hinterlegte GitHub-PAT wird nun korrekt an git-Netzwerkoperationen (push, pull, fetch) weitergegeben
- Die Remote-URL wird bei HTTPS-GitHub-Remotes mit den Credentials angereichert, wodurch der Git Credential Manager (GCM) umgangen wird
- Bei 403-Fehlern wird eine klare Fehlermeldung mit Hinweis auf die benötigten PAT-Berechtigungen angezeigt

## Root Cause

Die bisherige Implementierung versuchte Credentials über `GIT_CONFIG_*` Umgebungsvariablen bzw. `-c http.extraheader` zu injizieren. Beide Ansätze wurden vom Windows Git Credential Manager überschrieben, der seine eigenen (falsch konfigurierten) Credentials verwendete.

## Lösung

`BuildAuthenticatedArguments` liest die Remote-URL live aus LibGit2Sharp und baut daraus eine authentifizierte URL (`https://oauth2:TOKEN@github.com/...`). Diese wird direkt als Remote-Argument an den git-Prozess übergeben. Git verwendet eingebettete URL-Credentials ohne den Credential-Helper aufzurufen.

## Test plan

- [x] PAT mit `Contents: Write` in ghGPT hinterlegen
- [x] Push auf ein GitHub-HTTPS-Remote ausführen → muss erfolgreich sein
- [x] Pull auf ein GitHub-HTTPS-Remote ausführen → muss erfolgreich sein
- [x] Push ohne hinterlegten PAT → muss mit verständlicher Fehlermeldung scheitern
- [x] Push mit PAT ohne `repo`-Scope → muss die neue 403-Fehlermeldung anzeigen

Closes #45