### PR TITLE
fix: fetch schlägt fehl mit --all flag (#47)

### DIFF
--- a/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
+++ b/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
@@ -564,7 +564,7 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
         };
     }
 
-    private string BuildAuthenticatedArguments(string arguments, string localPath)
+    internal string BuildAuthenticatedArguments(string arguments, string localPath)
     {
         var token = tokenStore.Load();
         if (token is null)
@@ -582,6 +582,9 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
         }
 
         if (remoteUrl is null || !remoteUrl.StartsWith("https://github.com", StringComparison.OrdinalIgnoreCase))
+            return arguments;
+
+        if (arguments.Split(' ').Any(a => a == "--all"))
             return arguments;
 
         var authenticatedUrl = remoteUrl.Replace("https://github.com/", $"https://oauth2:{token}@github.com/", StringComparison.OrdinalIgnoreCase);

--- a/tests/ghGPT.Infrastructure.Tests/RepositoryServiceTests.cs
+++ b/tests/ghGPT.Infrastructure.Tests/RepositoryServiceTests.cs
@@ -608,6 +608,19 @@ public class RepositoryServiceTests : IDisposable
     }
 
     [Fact]
+    public void BuildAuthenticatedArguments_DoesNotInjectUrl_WhenAllFlagIsPresent()
+    {
+        var path = CreateGitRepo("fetch-all-repo");
+        Run("git remote add origin https://github.com/fake/repo.git", path);
+        _tokenStore.Load().Returns("fake-token");
+        var service = ServiceWithRepo(path);
+
+        var result = service.BuildAuthenticatedArguments("fetch --all --progress", path);
+
+        Assert.Equal("fetch --all --progress", result);
+    }
+
+    [Fact]
     public async Task PullAsync_UpdatesLocalBranchFromRemote()
     {
         var (_, localPath, peerPath) = CreateRemoteRepos("pull-repo");


### PR DESCRIPTION
## Summary

- `BuildAuthenticatedArguments` injiziert keine Remote-URL mehr, wenn `--all` im Argument enthalten ist
- `--all` und ein explizites Repository-Argument schließen sich bei `git fetch` gegenseitig aus
- Methode auf `internal` geändert, um direktes Unit-Testing zu ermöglichen

## Test plan

- [x] `BuildAuthenticatedArguments_DoesNotInjectUrl_WhenAllFlagIsPresent` — prüft, dass bei `fetch --all --progress` mit konfiguriertem Token keine URL injiziert wird
- [x] Bestehende Tests weiterhin grün

Closes #47