### PR TITLE
fix: Unbehandelte ApiException in PullRequestService abfangen (#56)

### DIFF
--- a/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
+++ b/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
@@ -57,6 +57,10 @@ public class PullRequestService(ITokenStore tokenStore) : IPullRequestService
         {
             throw new InvalidOperationException("GitHub API Rate Limit erreicht. Bitte später erneut versuchen.");
         }
+        catch (ApiException ex)
+        {
+            throw new InvalidOperationException($"GitHub API Fehler: {ex.Message}");
+        }
     }
 
     public async Task<PullRequestDetail> GetPullRequestDetailAsync(string owner, string repo, int number)
@@ -129,6 +133,10 @@ public class PullRequestService(ITokenStore tokenStore) : IPullRequestService
         catch (RateLimitExceededException)
         {
             throw new InvalidOperationException("GitHub API Rate Limit erreicht. Bitte später erneut versuchen.");
+        }
+        catch (ApiException ex)
+        {
+            throw new InvalidOperationException($"GitHub API Fehler: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary

- `GetPullRequestsAsync` und `GetPullRequestDetailAsync` fangen nun `ApiException` als Fallback für alle nicht explizit behandelten GitHub API Fehler (z.B. HTTP 422, 500, fehlender Token-Scope)
- Die spezifischeren Catches (`AuthorizationException`, `NotFoundException`, `RateLimitExceededException`) bleiben unverändert und werden vorrangig ausgewertet

## Test plan

- [ ] Pull Requests laden mit ungültigem/eingeschränktem Token → verständliche Fehlermeldung statt unbehandelte Exception
- [ ] Normaler Betrieb weiterhin funktionsfähig

Closes #56