### PR TITLE
fix: Gelöschte Remote-Branches werden nach Fetch entfernt (#58)

### DIFF
--- a/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
+++ b/src/ghGPT.Infrastructure/Repositories/RepositoryService.cs
@@ -409,7 +409,7 @@ public class RepositoryService(IRepositoryStore store, ITokenStore tokenStore) :
     }
 
     public Task FetchAsync(string id, IProgress<string>? progress = null) =>
-        RunGitOperationAsync(id, "fetch --all --progress", progress);
+        RunGitOperationAsync(id, "fetch --all --prune --progress", progress);
 
     public Task PullAsync(string id, IProgress<string>? progress = null) =>
         RunGitOperationAsync(id, "pull --progress", progress);


### PR DESCRIPTION
## Summary

- `--prune` zu `git fetch --all` hinzugefügt — beim Fetch werden nun veraltete Remote-Tracking-Refs (`refs/remotes/origin/*`) für auf GitHub gelöschte Branches automatisch entfernt

## Test plan

- [x] Branch auf GitHub löschen → Fetch in der App ausführen → Branch verschwindet aus der Remote-Branch-Liste
- [x] Normaler Fetch-Betrieb weiterhin funktionsfähig

Closes #58