### PR TITLE
feat: Release Candidate für Windows, macOS und Linux (#60)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build (${{ matrix.runtime }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - runtime: win-x64
+            artifact: ghGPT-win-x64
+          - runtime: osx-x64
+            artifact: ghGPT-osx-x64
+          - runtime: osx-arm64
+            artifact: ghGPT-osx-arm64
+          - runtime: linux-x64
+            artifact: ghGPT-linux-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/ghGPT.Frontend/package-lock.json
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Publish
+        run: |
+          dotnet publish src/ghGPT.Api \
+            -c Release \
+            -r ${{ matrix.runtime }} \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:UseAppHost=true \
+            -o ./publish/${{ matrix.runtime }}
+
+      - name: Zip artifact
+        run: |
+          cd publish/${{ matrix.runtime }}
+          zip -r ../../${{ matrix.artifact }}.zip .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.zip
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.zip
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+          generate_release_notes: true

--- a/src/ghGPT.Api/ghGPT.Api.csproj
+++ b/src/ghGPT.Api/ghGPT.Api.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UseAppHost>false</UseAppHost>
+    <UseAppHost Condition="'$(Configuration)' != 'Release'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Neuer GitHub Actions Workflow `.github/workflows/release.yml`
- Ausgelöst durch `v*`-Tags (z.B. `v1.0.0-rc.1`)
- Baut self-contained Single-File-Executables für 4 Plattformen parallel:
  - `ghGPT-win-x64.zip` → `ghGPT.Api.exe`
  - `ghGPT-osx-x64.zip` → `ghGPT.Api`
  - `ghGPT-osx-arm64.zip` → `ghGPT.Api`
  - `ghGPT-linux-x64.zip` → `ghGPT.Api`
- Frontend wird automatisch als Teil des Build-Prozesses eingebettet
- RC/Alpha/Beta-Tags werden als GitHub Pre-release markiert
- `UseAppHost` nur für Release-Builds aktiviert (Debug-Build unverändert)

## Release auslösen

```bash
git tag v1.0.0-rc.1
git push origin v1.0.0-rc.1
```

## Test plan

- [ ] Tag pushen → Workflow läuft durch
- [ ] Alle 4 ZIP-Artefakte im GitHub Release vorhanden
- [ ] `ghGPT.Api.exe` auf Windows ohne installiertes .NET startbar
- [ ] App öffnet UI im Browser unter `http://localhost:5000`
- [ ] RC-Tag wird als Pre-release markiert

Closes #60