### PR TITLE
feat: Linux-Tokenspeicherung implementiert (#62)

### DIFF
--- a/src/ghGPT.Infrastructure/Account/LinuxTokenStore.cs
+++ b/src/ghGPT.Infrastructure/Account/LinuxTokenStore.cs
@@ -1,0 +1,34 @@
+using System.Runtime.Versioning;
+
+namespace ghGPT.Infrastructure.Account;
+
+[UnsupportedOSPlatform("windows")]
+[UnsupportedOSPlatform("osx")]
+internal sealed class LinuxTokenStore : ITokenStore
+{
+    private static readonly string TokenFilePath =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ghGPT", "token");
+
+    public void Save(string token)
+    {
+        var directory = Path.GetDirectoryName(TokenFilePath)!;
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(TokenFilePath, token);
+        File.SetUnixFileMode(TokenFilePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    public string? Load()
+    {
+        if (!File.Exists(TokenFilePath))
+            return null;
+
+        var token = File.ReadAllText(TokenFilePath).Trim();
+        return string.IsNullOrEmpty(token) ? null : token;
+    }
+
+    public void Delete()
+    {
+        if (File.Exists(TokenFilePath))
+            File.Delete(TokenFilePath);
+    }
+}

--- a/src/ghGPT.Infrastructure/DependencyInjection.cs
+++ b/src/ghGPT.Infrastructure/DependencyInjection.cs
@@ -19,7 +19,7 @@ public static class DependencyInjection
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             services.AddSingleton<ITokenStore, MacOsTokenStore>();
         else
-            throw new PlatformNotSupportedException("Token-Speicherung wird auf dieser Plattform nicht unterstützt.");
+            services.AddSingleton<ITokenStore, LinuxTokenStore>();
 
         services.AddSingleton<IRepositoryStore, RepositoryStore>();
         services.AddSingleton<IRepositoryService, RepositoryService>();


### PR DESCRIPTION
## Summary

- Neue `LinuxTokenStore`-Klasse speichert den GitHub-Token unter `~/.config/ghGPT/token` mit Dateiberechtigungen `600`
- `DependencyInjection.cs`: `else`-Zweig wirft nicht mehr `PlatformNotSupportedException`, sondern registriert `LinuxTokenStore`

## Test plan

- [x] App startet unter Linux ohne Exception
- [x] GitHub-Account kann unter Linux verbunden und getrennt werden
- [x] Token wird in `~/.config/ghGPT/token` gespeichert (nur für den aktuellen Benutzer lesbar)

Closes #62