### PR TITLE
feat: Ollama Client Service (#13)

### DIFF
--- a/src/ghGPT.Api/Controllers/AiController.cs
+++ b/src/ghGPT.Api/Controllers/AiController.cs
@@ -1,0 +1,47 @@
+using ghGPT.Core.Ai;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ghGPT.Api.Controllers;
+
+[ApiController]
+[Route("api/ai")]
+public class AiController(IOllamaClient ollamaClient, IAiSettingsService settingsService) : ControllerBase
+{
+    [HttpGet("status")]
+    public async Task<ActionResult<OllamaStatus>> GetStatus()
+    {
+        var settings = settingsService.Load();
+        var online = await ollamaClient.IsAvailableAsync();
+
+        return Ok(new OllamaStatus
+        {
+            Online = online,
+            BaseUrl = settings.BaseUrl,
+            Model = settings.Model
+        });
+    }
+
+    [HttpGet("models")]
+    public async Task<ActionResult<IReadOnlyList<OllamaModelInfo>>> GetModels()
+    {
+        try
+        {
+            var models = await ollamaClient.GetModelsAsync();
+            return Ok(models);
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(503, "Ollama ist nicht erreichbar.");
+        }
+    }
+
+    [HttpPut("settings")]
+    public IActionResult SaveSettings([FromBody] OllamaSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.BaseUrl) || string.IsNullOrWhiteSpace(settings.Model))
+            return BadRequest("BaseUrl und Model dürfen nicht leer sein.");
+
+        settingsService.Save(settings);
+        return NoContent();
+    }
+}

--- a/src/ghGPT.Core/Ai/IAiSettingsService.cs
+++ b/src/ghGPT.Core/Ai/IAiSettingsService.cs
@@ -1,0 +1,7 @@
+namespace ghGPT.Core.Ai;
+
+public interface IAiSettingsService
+{
+    OllamaSettings Load();
+    void Save(OllamaSettings settings);
+}

--- a/src/ghGPT.Core/Ai/IOllamaClient.cs
+++ b/src/ghGPT.Core/Ai/IOllamaClient.cs
@@ -1,0 +1,8 @@
+namespace ghGPT.Core.Ai;
+
+public interface IOllamaClient
+{
+    Task<bool> IsAvailableAsync();
+    Task<IReadOnlyList<OllamaModelInfo>> GetModelsAsync();
+    IAsyncEnumerable<string> GenerateAsync(string prompt, CancellationToken cancellationToken = default);
+}

--- a/src/ghGPT.Core/Ai/OllamaModelInfo.cs
+++ b/src/ghGPT.Core/Ai/OllamaModelInfo.cs
@@ -1,0 +1,8 @@
+namespace ghGPT.Core.Ai;
+
+public class OllamaModelInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public DateTime ModifiedAt { get; set; }
+}

--- a/src/ghGPT.Core/Ai/OllamaSettings.cs
+++ b/src/ghGPT.Core/Ai/OllamaSettings.cs
@@ -1,0 +1,7 @@
+namespace ghGPT.Core.Ai;
+
+public class OllamaSettings
+{
+    public string BaseUrl { get; set; } = "http://localhost:11434";
+    public string Model { get; set; } = "llama3.2";
+}

--- a/src/ghGPT.Core/Ai/OllamaStatus.cs
+++ b/src/ghGPT.Core/Ai/OllamaStatus.cs
@@ -1,0 +1,8 @@
+namespace ghGPT.Core.Ai;
+
+public class OllamaStatus
+{
+    public bool Online { get; set; }
+    public string BaseUrl { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+}

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -8,8 +8,9 @@ import './changes-view';
 import './history-view';
 import './branches-view';
 import './pull-requests-view';
+import './settings-view';
 
-type View = 'changes' | 'history' | 'branches' | 'pull-requests';
+type View = 'changes' | 'history' | 'branches' | 'pull-requests' | 'settings';
 
 @customElement('app-shell')
 export class AppShell extends LitElement {
@@ -922,6 +923,12 @@ export class AppShell extends LitElement {
             @click=${() => this.activeView = 'pull-requests'}>
             <span>🔀</span> Pull Requests
           </div>
+
+          <div class="sidebar-section-title" style="margin-top:0.5rem">App</div>
+          <div class="nav-item ${this.activeView === 'settings' ? 'active' : ''}"
+            @click=${() => this.activeView = 'settings'}>
+            <span>⚙</span> Einstellungen
+          </div>
         </div>
 
         <div class="sidebar-footer" @click=${() => { this.showAccountDialog = true; this.accountError = ''; }}>
@@ -982,8 +989,9 @@ export class AppShell extends LitElement {
           <button class="toolbar-btn" ?disabled=${!this.activeRepo || !!this.gitOperation} @click=${() => this.runGitOperation('push')}>${this.renderPushButtonLabel()}</button>
         </div>
 
-        <div class="content ${this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests' ? 'padded' : ''}">
-          ${this.activeRepo ? this.renderView() : html`
+        <div class="content ${this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests' ? 'padded' : ''}"
+          style="${this.activeView === 'settings' ? 'overflow:auto' : ''}">
+          ${this.activeRepo || this.activeView === 'settings' ? this.renderView() : html`
             <div class="placeholder">
               <span class="placeholder-icon">📂</span>
               <span>Kein Repository geöffnet</span>
@@ -1087,6 +1095,8 @@ export class AppShell extends LitElement {
         return html`<branches-view .repoId=${this.activeRepoId ?? ''} .refreshKey=${this.historyRefreshKey} @branch-changed=${this.onBranchChanged}></branches-view>`;
       case 'pull-requests':
         return html`<pull-requests-view .repoId=${this.activeRepoId ?? ''}></pull-requests-view>`;
+      case 'settings':
+        return html`<settings-view></settings-view>`;
     }
   }
 }

--- a/src/ghGPT.Frontend/src/components/settings-view.ts
+++ b/src/ghGPT.Frontend/src/components/settings-view.ts
@@ -1,0 +1,254 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { aiService, type OllamaStatus, type OllamaModelInfo } from '../services/ai-service';
+
+@customElement('settings-view')
+export class SettingsView extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      padding: 1.5rem;
+      color: #cdd6f4;
+      max-width: 640px;
+    }
+
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin: 0 0 1.5rem;
+      color: #cdd6f4;
+    }
+
+    .section {
+      margin-bottom: 2rem;
+    }
+
+    .section-title {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6c7086;
+      margin-bottom: 0.75rem;
+    }
+
+    .card {
+      background: #1e1e2e;
+      border: 1px solid #313244;
+      border-radius: 8px;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+
+    .field label {
+      font-size: 0.78rem;
+      color: #a6adc8;
+    }
+
+    .field input,
+    .field select {
+      padding: 0.45rem 0.75rem;
+      border-radius: 6px;
+      border: 1px solid #45475a;
+      background: #181825;
+      color: #cdd6f4;
+      font-size: 0.875rem;
+      font-family: inherit;
+    }
+
+    .field input:focus,
+    .field select:focus {
+      outline: none;
+      border-color: #89b4fa;
+    }
+
+    .field select option { background: #1e1e2e; }
+
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .status-dot.online  { background: #a6e3a1; }
+    .status-dot.offline { background: #f38ba8; }
+    .status-dot.loading { background: #f9e2af; }
+
+    .status-text {
+      font-size: 0.83rem;
+      color: #a6adc8;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      margin-top: 0.25rem;
+    }
+
+    button {
+      padding: 0.4rem 1rem;
+      border-radius: 6px;
+      border: 1px solid #45475a;
+      background: transparent;
+      color: #cdd6f4;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+
+    button:hover { background: #313244; }
+
+    button.primary {
+      background: #89b4fa22;
+      border-color: #89b4fa;
+      color: #89b4fa;
+    }
+
+    button.primary:hover { background: #89b4fa44; }
+
+    button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .success-msg {
+      font-size: 0.8rem;
+      color: #a6e3a1;
+    }
+
+    .error-msg {
+      font-size: 0.8rem;
+      color: #f38ba8;
+    }
+  `;
+
+  @state() private status: OllamaStatus | null = null;
+  @state() private statusLoading = true;
+  @state() private models: OllamaModelInfo[] = [];
+  @state() private baseUrl = 'http://localhost:11434';
+  @state() private model = 'llama3.2';
+  @state() private saving = false;
+  @state() private saveResult: 'success' | 'error' | null = null;
+
+  async connectedCallback() {
+    super.connectedCallback();
+    await this.loadStatus();
+  }
+
+  private async loadStatus() {
+    this.statusLoading = true;
+    try {
+      this.status = await aiService.getStatus();
+      this.baseUrl = this.status.baseUrl;
+      this.model = this.status.model;
+
+      if (this.status.online) {
+        this.models = await aiService.getModels().catch(() => []);
+      }
+    } catch {
+      this.status = null;
+    } finally {
+      this.statusLoading = false;
+    }
+  }
+
+  private async saveSettings() {
+    this.saving = true;
+    this.saveResult = null;
+    try {
+      await aiService.saveSettings({ baseUrl: this.baseUrl, model: this.model });
+      this.saveResult = 'success';
+      await this.loadStatus();
+    } catch {
+      this.saveResult = 'error';
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  private renderStatusDot() {
+    if (this.statusLoading) return html`<span class="status-dot loading"></span>`;
+    return html`<span class="status-dot ${this.status?.online ? 'online' : 'offline'}"></span>`;
+  }
+
+  render() {
+    return html`
+      <h2>Einstellungen</h2>
+
+      <div class="section">
+        <div class="section-title">Ollama</div>
+        <div class="card">
+          <div class="row">
+            ${this.renderStatusDot()}
+            <span class="status-text">
+              ${this.statusLoading
+                ? 'Verbindung wird geprüft…'
+                : this.status?.online
+                  ? `Verbunden · Modell: ${this.status.model}`
+                  : 'Nicht erreichbar'}
+            </span>
+            <button style="margin-left:auto;padding:0.25rem 0.6rem;font-size:0.78rem"
+              @click=${() => this.loadStatus()} ?disabled=${this.statusLoading}>
+              ↻
+            </button>
+          </div>
+
+          <div class="field">
+            <label>Ollama URL</label>
+            <input
+              type="text"
+              .value=${this.baseUrl}
+              @input=${(e: Event) => { this.baseUrl = (e.target as HTMLInputElement).value; this.saveResult = null; }}
+            />
+          </div>
+
+          <div class="field">
+            <label>Modell</label>
+            ${this.models.length > 0
+              ? html`
+                <select .value=${this.model}
+                  @change=${(e: Event) => { this.model = (e.target as HTMLSelectElement).value; this.saveResult = null; }}>
+                  ${this.models.map(m => html`
+                    <option value=${m.name} ?selected=${m.name === this.model}>${m.name}</option>
+                  `)}
+                </select>
+              `
+              : html`
+                <input
+                  type="text"
+                  .value=${this.model}
+                  placeholder="z.B. llama3.2"
+                  @input=${(e: Event) => { this.model = (e.target as HTMLInputElement).value; this.saveResult = null; }}
+                />
+              `}
+          </div>
+
+          <div class="actions">
+            ${this.saveResult === 'success'
+              ? html`<span class="success-msg">Gespeichert ✓</span>`
+              : this.saveResult === 'error'
+                ? html`<span class="error-msg">Fehler beim Speichern</span>`
+                : ''}
+            <button class="primary" ?disabled=${this.saving} @click=${() => this.saveSettings()}>
+              ${this.saving ? 'Speichert…' : 'Speichern'}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/ghGPT.Frontend/src/services/ai-service.ts
+++ b/src/ghGPT.Frontend/src/services/ai-service.ts
@@ -1,0 +1,24 @@
+import { api } from './api-client';
+
+export interface OllamaSettings {
+  baseUrl: string;
+  model: string;
+}
+
+export interface OllamaStatus {
+  online: boolean;
+  baseUrl: string;
+  model: string;
+}
+
+export interface OllamaModelInfo {
+  name: string;
+  size: number;
+  modifiedAt: string;
+}
+
+export const aiService = {
+  getStatus: () => api.get<OllamaStatus>('/ai/status'),
+  getModels: () => api.get<OllamaModelInfo[]>('/ai/models'),
+  saveSettings: (settings: OllamaSettings) => api.put<void>('/ai/settings', settings),
+};

--- a/src/ghGPT.Infrastructure/Ai/AiSettingsService.cs
+++ b/src/ghGPT.Infrastructure/Ai/AiSettingsService.cs
@@ -1,0 +1,35 @@
+using ghGPT.Core.Ai;
+using System.Text.Json;
+
+namespace ghGPT.Infrastructure.Ai;
+
+internal sealed class AiSettingsService : IAiSettingsService
+{
+    private static readonly string SettingsFilePath =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ghGPT", "ai-settings.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public OllamaSettings Load()
+    {
+        if (!File.Exists(SettingsFilePath))
+            return new OllamaSettings();
+
+        try
+        {
+            var json = File.ReadAllText(SettingsFilePath);
+            return JsonSerializer.Deserialize<OllamaSettings>(json) ?? new OllamaSettings();
+        }
+        catch
+        {
+            return new OllamaSettings();
+        }
+    }
+
+    public void Save(OllamaSettings settings)
+    {
+        var directory = Path.GetDirectoryName(SettingsFilePath)!;
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(SettingsFilePath, JsonSerializer.Serialize(settings, JsonOptions));
+    }
+}

--- a/src/ghGPT.Infrastructure/Ai/OllamaClient.cs
+++ b/src/ghGPT.Infrastructure/Ai/OllamaClient.cs
@@ -1,0 +1,104 @@
+using ghGPT.Core.Ai;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ghGPT.Infrastructure.Ai;
+
+internal sealed class OllamaClient(IAiSettingsService settingsService) : IOllamaClient
+{
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+    public async Task<bool> IsAvailableAsync()
+    {
+        var settings = settingsService.Load();
+        try
+        {
+            var response = await _http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/api/tags");
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<OllamaModelInfo>> GetModelsAsync()
+    {
+        var settings = settingsService.Load();
+        var response = await _http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/api/tags");
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<OllamaTagsResponse>();
+        return result?.Models?.Select(m => new OllamaModelInfo
+        {
+            Name = m.Name,
+            Size = m.Size,
+            ModifiedAt = m.ModifiedAt
+        }).ToList() ?? [];
+    }
+
+    public async IAsyncEnumerable<string> GenerateAsync(
+        string prompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var settings = settingsService.Load();
+        var requestBody = new { model = settings.Model, prompt, stream = true };
+        var content = JsonContent.Create(requestBody);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{settings.BaseUrl.TrimEnd('/')}/api/generate")
+        {
+            Content = content
+        };
+
+        using var response = await new HttpClient { Timeout = TimeSpan.FromMinutes(5) }
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new System.IO.StreamReader(stream);
+
+        while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (string.IsNullOrEmpty(line)) continue;
+
+            var chunk = JsonSerializer.Deserialize<OllamaGenerateChunk>(line);
+            if (chunk is null) continue;
+
+            if (!string.IsNullOrEmpty(chunk.Response))
+                yield return chunk.Response;
+
+            if (chunk.Done) break;
+        }
+    }
+
+    private sealed class OllamaTagsResponse
+    {
+        [JsonPropertyName("models")]
+        public List<OllamaModelEntry>? Models { get; set; }
+    }
+
+    private sealed class OllamaModelEntry
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("size")]
+        public long Size { get; set; }
+
+        [JsonPropertyName("modified_at")]
+        public DateTime ModifiedAt { get; set; }
+    }
+
+    private sealed class OllamaGenerateChunk
+    {
+        [JsonPropertyName("response")]
+        public string Response { get; set; } = string.Empty;
+
+        [JsonPropertyName("done")]
+        public bool Done { get; set; }
+    }
+}

--- a/src/ghGPT.Infrastructure/DependencyInjection.cs
+++ b/src/ghGPT.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using ghGPT.Core.Account;
+using ghGPT.Core.Ai;
 using ghGPT.Core.PullRequests;
 using ghGPT.Core.Repositories;
 using ghGPT.Infrastructure.Account;
+using ghGPT.Infrastructure.Ai;
 using ghGPT.Infrastructure.PullRequests;
 using ghGPT.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +22,9 @@ public static class DependencyInjection
             services.AddSingleton<ITokenStore, MacOsTokenStore>();
         else
             services.AddSingleton<ITokenStore, LinuxTokenStore>();
+
+        services.AddSingleton<IAiSettingsService, AiSettingsService>();
+        services.AddSingleton<IOllamaClient, OllamaClient>();
 
         services.AddSingleton<IRepositoryStore, RepositoryStore>();
         services.AddSingleton<IRepositoryService, RepositoryService>();


### PR DESCRIPTION
## Summary

- `IOllamaClient` mit `IsAvailableAsync`, `GetModelsAsync` und `GenerateAsync` (streaming via `IAsyncEnumerable<string>`)
- `IAiSettingsService` / `AiSettingsService` speichert Ollama-URL und Modellname in `~/.config/ghGPT/ai-settings.json`
- API-Endpoints: `GET /api/ai/status`, `GET /api/ai/models`, `PUT /api/ai/settings`
- Settings-View im Frontend: Ollama-Status-Indikator, URL/Modell konfigurierbar, Modell-Dropdown wenn Ollama erreichbar

## Test plan

- [ ] Ollama starten (`ollama serve`) und ein Modell laden (`ollama pull llama3.2`)
- [ ] App starten → Einstellungen öffnen → Status zeigt "Verbunden"
- [ ] Modell-Dropdown zeigt verfügbare Modelle
- [ ] URL/Modell ändern und speichern → Status aktualisiert sich
- [ ] Ollama stoppen → Status zeigt "Nicht erreichbar"
- [ ] `GET /api/ai/models` gibt 503 zurück wenn Ollama offline

Closes #13