### PR TITLE
feat: Basis-Kontextinjektion (#70)

### DIFF
--- a/src/ghGPT.Infrastructure/Ai/ChatService.cs
+++ b/src/ghGPT.Infrastructure/Ai/ChatService.cs
@@ -1,9 +1,11 @@
 using ghGPT.Core.Ai;
+using ghGPT.Core.Repositories;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace ghGPT.Infrastructure.Ai;
 
-internal sealed class ChatService(IOllamaClient ollamaClient) : IChatService
+internal sealed class ChatService(IOllamaClient ollamaClient, IRepositoryService repositoryService) : IChatService
 {
     public async IAsyncEnumerable<string> StreamAsync(
         ChatRequest request,
@@ -17,13 +19,72 @@ internal sealed class ChatService(IOllamaClient ollamaClient) : IChatService
         }
     }
 
-    private static IEnumerable<ChatMessage> BuildMessages(ChatRequest request)
+    private IEnumerable<ChatMessage> BuildMessages(ChatRequest request)
     {
         yield return new ChatMessage
         {
             Role = "system",
             Content = SystemPrompt.Build(request.RepoId, request.Branch)
         };
+
+        var context = BuildRepositoryContext(request.RepoId);
+        if (context is not null)
+            yield return new ChatMessage { Role = "system", Content = context };
+
         yield return new ChatMessage { Role = "user", Content = request.Message };
+    }
+
+    private string? BuildRepositoryContext(string? repoId)
+    {
+        if (string.IsNullOrEmpty(repoId)) return null;
+
+        try
+        {
+            var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
+            if (repo is null) return null;
+
+            var sb = new StringBuilder();
+            sb.AppendLine("## Repository-Kontext");
+            sb.AppendLine($"- Name: {repo.Name}");
+            sb.AppendLine($"- Pfad: {repo.LocalPath}");
+
+            if (!string.IsNullOrEmpty(repo.RemoteUrl))
+                sb.AppendLine($"- Remote: {repo.RemoteUrl}");
+
+            var branches = repositoryService.GetBranches(repoId);
+            var head = branches.FirstOrDefault(b => b.IsHead && !b.IsRemote);
+            if (head is not null)
+            {
+                sb.Append($"- Aktueller Branch: {head.Name}");
+                if (head.TrackingBranch is not null)
+                {
+                    if (head.AheadBy > 0 || head.BehindBy > 0)
+                        sb.Append($" (↑{head.AheadBy} voraus, ↓{head.BehindBy} zurück)");
+                    else
+                        sb.Append(" (aktuell)");
+                }
+                sb.AppendLine();
+            }
+
+            var commits = repositoryService.GetHistory(repoId, limit: 5);
+            if (commits.Count > 0)
+            {
+                sb.AppendLine("- Letzte Commits:");
+                foreach (var c in commits)
+                    sb.AppendLine($"  - {c.ShortSha} {c.Message} ({c.AuthorName})");
+            }
+
+            var status = repositoryService.GetStatus(repoId);
+            var stagedCount = status.Staged.Count;
+            var unstagedCount = status.Unstaged.Count;
+            if (stagedCount > 0 || unstagedCount > 0)
+                sb.AppendLine($"- Änderungen: {stagedCount} staged, {unstagedCount} unstaged");
+
+            return sb.ToString().TrimEnd();
+        }
+        catch
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary

`ChatService` ruft bei jedem Request automatisch `IRepositoryService` auf und injiziert eine zweite `system`-Message nach dem Haupt-System-Prompt:

```
## Repository-Kontext
- Name: ghGPT
- Pfad: /home/user/repos/ghGPT
- Remote: https://github.com/slekrem/ghGPT.git
- Aktueller Branch: main (↑2 voraus, aktuell)
- Letzte Commits:
  - abc1234 feat: Chat-Panel implementiert (Stefan)
  - def5678 fix: Timeout reduziert (Stefan)
- Änderungen: 1 staged, 3 unstaged
```

- Kein extra Interface nötig — `IRepositoryService` wird direkt injiziert
- Fehler beim Kontext-Abruf werden still ignoriert (Chat funktioniert auch ohne Repo)
- Frontend bereits korrekt verdrahtet (`repoId` + `branch` werden übergeben)

## Test plan

- [x] Chat öffnen mit aktivem Repository → LLM nennt korrekt Branch und Commits ohne explizite Frage
- [x] Chat ohne aktives Repository → funktioniert weiterhin, kein Fehler
- [x] "Wie viele Commits bin ich voraus?" → LLM antwortet korrekt basierend auf Ahead/Behind

Closes #70