### PR TITLE
fix: Stale PR-Antworten bei Repository-Wechsel ignorieren (#81)

### DIFF
--- a/src/ghGPT.Frontend/src/components/pull-requests-view.ts
+++ b/src/ghGPT.Frontend/src/components/pull-requests-view.ts
@@ -475,28 +475,36 @@ export class PullRequestsView extends LitElement {
   }
 
   private async loadPrs() {
+    const requestedRepoId = this.repoId;
     this.loading = true;
     this.error = null;
     try {
-      this.prs = await repositoryService.getPullRequests(this.repoId, this.stateFilter);
+      const result = await repositoryService.getPullRequests(requestedRepoId, this.stateFilter);
+      if (this.repoId !== requestedRepoId) return;
+      this.prs = result;
     } catch (e: unknown) {
+      if (this.repoId !== requestedRepoId) return;
       this.error = e instanceof Error ? e.message : 'Fehler beim Laden der Pull Requests.';
     } finally {
-      this.loading = false;
+      if (this.repoId === requestedRepoId) this.loading = false;
     }
   }
 
   private async selectPr(number: number) {
+    const requestedRepoId = this.repoId;
     this.selectedNumber = number;
     this.selectedPr = null;
     this.detailError = null;
     this.loadingDetail = true;
     try {
-      this.selectedPr = await repositoryService.getPullRequestDetail(this.repoId, number);
+      const result = await repositoryService.getPullRequestDetail(requestedRepoId, number);
+      if (this.repoId !== requestedRepoId || this.selectedNumber !== number) return;
+      this.selectedPr = result;
     } catch (e: unknown) {
+      if (this.repoId !== requestedRepoId || this.selectedNumber !== number) return;
       this.detailError = e instanceof Error ? e.message : 'Fehler beim Laden des PR-Details.';
     } finally {
-      this.loadingDetail = false;
+      if (this.repoId === requestedRepoId && this.selectedNumber === number) this.loadingDetail = false;
     }
   }
 


### PR DESCRIPTION
## Summary
- `loadPrs` und `selectPr` snapshotten `repoId` (und PR-Nummer) vor dem `await`
- Nach dem Resolve wird geprüft ob der Snapshot noch mit dem aktuellen Wert übereinstimmt
- Veraltete Antworten werden verworfen ohne den State zu überschreiben
- `loading`/`loadingDetail` wird ebenfalls nur zurückgesetzt wenn die Antwort noch aktuell ist

## Test plan
- [x] Repository A auswählen (PR-Liste lädt), schnell zu Repository B wechseln → nur PRs von B werden angezeigt
- [x] PR-Details laden, während Repository gewechselt wird → Details vom alten Repo erscheinen nicht
- [x] Manuelles Aktualisieren funktioniert weiterhin für das aktive Repository
- [x] Alle 109 bestehenden Tests bestehen weiterhin