### PR TITLE
refactor(e2e): CSS-Klassen durch data-testid Attribute ersetzen

### DIFF
--- a/src/ghGPT.Frontend/e2e/app.spec.ts
+++ b/src/ghGPT.Frontend/e2e/app.spec.ts
@@ -5,11 +5,11 @@ test.describe('Repository List', () => {
     await page.goto('/');
     await page.locator('app-shell').waitFor();
 
-    const repoItems = page.locator('.repo-item');
+    const repoItems = page.locator('[data-testid="repo-item"]');
     const count = await repoItems.count();
 
     for (let i = 0; i < count; i++) {
-      await expect(repoItems.nth(i).locator('.repo-name')).toBeVisible();
+      await expect(repoItems.nth(i).locator('[data-testid="repo-name"]')).toBeVisible();
     }
   });
 
@@ -31,7 +31,7 @@ test.describe('App Shell', () => {
     await page.goto('/');
     await page.locator('app-shell').waitFor();
 
-    const addBtn = page.locator('.add-btn');
+    const addBtn = page.locator('[data-testid="add-repo-btn"]');
     await expect(addBtn).toBeVisible();
     await addBtn.first().click();
     await expect(page.locator('repo-dialog')).toBeAttached();
@@ -41,7 +41,7 @@ test.describe('App Shell', () => {
     await page.goto('/');
     await page.locator('app-shell').waitFor();
 
-    await page.locator('.add-btn').first().click();
+    await page.locator('[data-testid="add-repo-btn"]').first().click();
     await expect(page.locator('repo-dialog')).toBeAttached();
 
     await page.locator('repo-dialog').locator('button', { hasText: 'Abbrechen' }).click();

--- a/src/ghGPT.Frontend/e2e/branches-view-remote.spec.ts
+++ b/src/ghGPT.Frontend/e2e/branches-view-remote.spec.ts
@@ -25,7 +25,7 @@ async function gotoBranchesView(page: import('@playwright/test').Page) {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
 }
 
@@ -34,20 +34,20 @@ async function gotoBranchesView(page: import('@playwright/test').Page) {
 test('shows remote branches section', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  await expect(view.locator('.section-title').filter({ hasText: /Remote Branches/i })).toBeVisible();
+  await expect(view.locator('[data-testid="section-title"]').filter({ hasText: /Remote Branches/i })).toBeVisible();
 });
 
 test('shows remote branch in list', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  await expect(view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' })).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' })).toBeVisible();
 });
 
 test('remote branch shows cloud icon', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  const remoteRow = view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' });
-  await expect(remoteRow.locator('.branch-icon')).toContainText('☁');
+  const remoteRow = view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' });
+  await expect(remoteRow.locator('[data-testid="branch-icon"]')).toContainText('☁');
 });
 
 // --- Checkout ---
@@ -55,21 +55,21 @@ test('remote branch shows cloud icon', async ({ page }) => {
 test('remote branch has checkout button on hover', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  const remoteRow = view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' });
+  const remoteRow = view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' });
   await remoteRow.hover();
-  await expect(remoteRow.locator('.action-btn', { hasText: 'Checkout' })).toBeVisible();
+  await expect(remoteRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' })).toBeVisible();
 });
 
 test('checkout of remote branch creates local tracking branch', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const remoteRow = view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' });
+  const remoteRow = view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' });
   await remoteRow.hover();
-  await remoteRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await remoteRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
-  await expect(view.locator('.branch-row.head').filter({ hasText: 'feature/remote-branch' })).toBeVisible({ timeout: 5000 });
-  await expect(view.locator('.branch-row.head .head-badge')).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"][data-head]').filter({ hasText: 'feature/remote-branch' })).toBeVisible({ timeout: 5000 });
+  await expect(view.locator('[data-testid="branch-row"][data-head] [data-testid="head-badge"]')).toBeVisible();
 
   // zurück zu master/main und lokalen Branch entfernen für folgende Tests
   try { execSync('git checkout master', { cwd: localDir, stdio: 'pipe' }); }
@@ -81,12 +81,12 @@ test('toolbar shows local branch name after remote checkout', async ({ page }) =
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const remoteRow = view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' });
+  const remoteRow = view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' });
   await remoteRow.hover();
-  await remoteRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await remoteRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
-  await expect(view.locator('.branch-row.head').filter({ hasText: 'feature/remote-branch' })).toBeVisible({ timeout: 5000 });
-  await expect(page.locator('.toolbar-branch')).toContainText('feature/remote-branch');
+  await expect(view.locator('[data-testid="branch-row"][data-head]').filter({ hasText: 'feature/remote-branch' })).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText('feature/remote-branch');
 
   try { execSync('git checkout master', { cwd: localDir, stdio: 'pipe' }); }
   catch { execSync('git checkout main', { cwd: localDir, stdio: 'pipe' }); }
@@ -107,9 +107,9 @@ test('checkout remote branch twice shows error', async ({ page }) => {
     await dialog.accept();
   });
 
-  const remoteRow = view.locator('.branch-row').filter({ hasText: 'origin/feature/remote-branch' });
+  const remoteRow = view.locator('[data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' });
   await remoteRow.hover();
-  await remoteRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await remoteRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
   await page.waitForEvent('dialog', { timeout: 5000 });
   expect(alertMessage).toMatch(/existiert bereits/i);
@@ -120,8 +120,8 @@ test('checkout remote branch twice shows error', async ({ page }) => {
 test('new branch dialog includes remote branches in base select', async ({ page }) => {
   await gotoBranchesView(page);
 
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
   await expect(dialog).toBeVisible();
 
   const options = await dialog.locator('select option').allTextContents();
@@ -131,14 +131,14 @@ test('new branch dialog includes remote branches in base select', async ({ page 
 test('creates local branch from remote branch as base', async ({ page }) => {
   await gotoBranchesView(page);
 
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
 
   await dialog.locator('input[type="text"]').fill('feature/from-remote');
   await dialog.locator('select').selectOption({ label: 'origin/feature/remote-branch' });
-  await dialog.locator('.btn-primary').filter({ hasText: 'Erstellen' }).click();
+  await dialog.locator('[data-testid="create-branch-btn"]').click();
 
-  await expect(page.locator('branches-view .dialog')).not.toBeVisible({ timeout: 5000 });
-  await expect(page.locator('branches-view .branch-row').filter({ hasText: 'feature/from-remote' })).toBeVisible();
-  await expect(page.locator('branches-view .branch-row.head').filter({ hasText: 'feature/from-remote' })).toBeVisible();
+  await expect(page.locator('branches-view [data-testid="new-branch-dialog"]')).not.toBeVisible({ timeout: 5000 });
+  await expect(page.locator('branches-view [data-testid="branch-row"]').filter({ hasText: 'feature/from-remote' })).toBeVisible();
+  await expect(page.locator('branches-view [data-testid="branch-row"][data-head]').filter({ hasText: 'feature/from-remote' })).toBeVisible();
 });

--- a/src/ghGPT.Frontend/e2e/branches-view.spec.ts
+++ b/src/ghGPT.Frontend/e2e/branches-view.spec.ts
@@ -37,7 +37,7 @@ async function gotoBranchesView(page: import('@playwright/test').Page) {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
 }
 
@@ -49,9 +49,9 @@ test('toolbar "Branch verwalten" navigates to branches view', async ({ page }) =
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown')).toBeVisible();
-  await page.locator('.branch-dropdown-footer').click();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).toBeVisible();
+  await page.locator('[data-testid="branch-dropdown-footer"]').click();
   await page.locator('branches-view').waitFor();
   await expect(page.locator('branches-view')).toBeVisible();
 });
@@ -62,98 +62,98 @@ test('toolbar branch button shows current branch name', async ({ page }) => {
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  await expect(page.locator('.toolbar-branch')).toContainText(/master|main/);
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText(/master|main/);
 });
 
 // --- Anzeige ---
 
 test('shows branches section title in toolbar', async ({ page }) => {
   await gotoBranchesView(page);
-  await expect(page.locator('branches-view .toolbar-title')).toContainText('Branches');
+  await expect(page.locator('branches-view [data-testid="toolbar-title"]')).toContainText('Branches');
 });
 
 test('shows local branches', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  await expect(view.locator('.branch-row').filter({ hasText: /master|main/ })).toBeVisible();
-  await expect(view.locator('.branch-row').filter({ hasText: 'develop' })).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"]').filter({ hasText: /master|main/ })).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"]').filter({ hasText: 'develop' })).toBeVisible();
 });
 
 test('marks current branch with HEAD badge', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  const headRow = view.locator('.branch-row.head');
+  const headRow = view.locator('[data-testid="branch-row"][data-head]');
   await expect(headRow).toBeVisible();
-  await expect(headRow.locator('.head-badge')).toBeVisible();
-  await expect(headRow.locator('.head-badge')).toContainText('HEAD');
+  await expect(headRow.locator('[data-testid="head-badge"]')).toBeVisible();
+  await expect(headRow.locator('[data-testid="head-badge"]')).toContainText('HEAD');
 });
 
 test('shows section title for local branches', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
-  await expect(view.locator('.section-title').filter({ hasText: /Lokale Branches/i })).toBeVisible();
+  await expect(view.locator('[data-testid="section-title"]').filter({ hasText: /Lokale Branches/i })).toBeVisible();
 });
 
 // --- Neuer Branch Dialog ---
 
 test('opens new branch dialog on button click', async ({ page }) => {
   await gotoBranchesView(page);
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
   await expect(dialog).toBeVisible();
-  await expect(dialog.locator('.dialog-title')).toContainText('Neuen Branch erstellen');
+  await expect(dialog.locator('[data-testid="dialog-title"]')).toContainText('Neuen Branch erstellen');
 });
 
 test('closes dialog on Abbrechen click', async ({ page }) => {
   await gotoBranchesView(page);
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  await expect(page.locator('branches-view .dialog')).toBeVisible();
-  await page.locator('branches-view .dialog .btn').filter({ hasText: 'Abbrechen' }).click();
-  await expect(page.locator('branches-view .dialog')).not.toBeVisible();
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  await expect(page.locator('branches-view [data-testid="new-branch-dialog"]')).toBeVisible();
+  await page.locator('branches-view [data-testid="new-branch-dialog"]').locator('button', { hasText: 'Abbrechen' }).click();
+  await expect(page.locator('branches-view [data-testid="new-branch-dialog"]')).not.toBeVisible();
 });
 
 test('shows validation error when creating branch with empty name', async ({ page }) => {
   await gotoBranchesView(page);
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
-  await dialog.locator('.btn-primary').filter({ hasText: 'Erstellen' }).click();
-  await expect(dialog.locator('.error-msg')).toBeVisible();
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
+  await dialog.locator('[data-testid="create-branch-btn"]').click();
+  await expect(dialog.locator('[data-testid="error-msg"]')).toBeVisible();
 });
 
 test('creates a new branch and shows it in the list', async ({ page }) => {
   await gotoBranchesView(page);
   const branchName = 'feature/e2e-create';
 
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
   await dialog.locator('input[type="text"]').fill(branchName);
-  await dialog.locator('.btn-primary').filter({ hasText: 'Erstellen' }).click();
+  await dialog.locator('[data-testid="create-branch-btn"]').click();
 
-  await expect(page.locator('branches-view .dialog')).not.toBeVisible({ timeout: 5000 });
-  await expect(page.locator('branches-view .branch-row').filter({ hasText: branchName })).toBeVisible();
+  await expect(page.locator('branches-view [data-testid="new-branch-dialog"]')).not.toBeVisible({ timeout: 5000 });
+  await expect(page.locator('branches-view [data-testid="branch-row"]').filter({ hasText: branchName })).toBeVisible();
 });
 
 test('new branch becomes HEAD after creation', async ({ page }) => {
   await gotoBranchesView(page);
   const branchName = 'feature/e2e-head-check';
 
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const dialog = page.locator('branches-view .dialog');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const dialog = page.locator('branches-view [data-testid="new-branch-dialog"]');
   await dialog.locator('input[type="text"]').fill(branchName);
-  await dialog.locator('.btn-primary').filter({ hasText: 'Erstellen' }).click();
+  await dialog.locator('[data-testid="create-branch-btn"]').click();
 
-  await expect(page.locator('branches-view .dialog')).not.toBeVisible({ timeout: 5000 });
+  await expect(page.locator('branches-view [data-testid="new-branch-dialog"]')).not.toBeVisible({ timeout: 5000 });
 
-  const newRow = page.locator('branches-view .branch-row').filter({ hasText: branchName });
-  await expect(newRow.locator('.head-badge')).toBeVisible();
+  const newRow = page.locator('branches-view [data-testid="branch-row"]').filter({ hasText: branchName });
+  await expect(newRow.locator('[data-testid="head-badge"]')).toBeVisible();
 
   checkoutDefaultBranch(repoDir);
 });
 
 test('dialog populates base-branch select with local branches', async ({ page }) => {
   await gotoBranchesView(page);
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  const select = page.locator('branches-view .dialog select');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  const select = page.locator('branches-view [data-testid="new-branch-dialog"] select');
   await expect(select).toBeVisible();
   const options = await select.locator('option').allTextContents();
   expect(options.length).toBeGreaterThan(0);
@@ -165,21 +165,21 @@ test('checkout button is visible on hover for non-HEAD local branches', async ({
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const nonHeadRow = view.locator('.branch-row:not(.head)').filter({ hasText: 'develop' }).first();
+  const nonHeadRow = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'develop' }).first();
   await nonHeadRow.hover();
-  await expect(nonHeadRow.locator('.action-btn', { hasText: 'Checkout' })).toBeVisible();
+  await expect(nonHeadRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' })).toBeVisible();
 });
 
 test('checkout switches to target branch', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const developRow = view.locator('.branch-row:not(.head)').filter({ hasText: 'develop' }).first();
+  const developRow = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'develop' }).first();
   await developRow.hover();
-  await developRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await developRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
-  await expect(view.locator('.branch-row.head').filter({ hasText: 'develop' })).toBeVisible({ timeout: 5000 });
-  await expect(view.locator('.branch-row.head').locator('.head-badge')).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"][data-head]').filter({ hasText: 'develop' })).toBeVisible({ timeout: 5000 });
+  await expect(view.locator('[data-testid="branch-row"][data-head]').locator('[data-testid="head-badge"]')).toBeVisible();
 
   checkoutDefaultBranch(repoDir);
 });
@@ -196,9 +196,9 @@ test('shows alert when checking out with uncommitted changes', async ({ page }) 
     await dialog.accept();
   });
 
-  const developRow = view.locator('.branch-row:not(.head)').filter({ hasText: 'develop' }).first();
+  const developRow = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'develop' }).first();
   await developRow.hover();
-  await developRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await developRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
   await page.waitForEvent('dialog', { timeout: 5000 });
   expect(alertMessage).toMatch(/uncommitted|changes|Änderungen/i);
@@ -213,9 +213,9 @@ test('delete button is visible on hover for non-HEAD branches', async ({ page })
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const nonHeadRow = view.locator('.branch-row:not(.head)').filter({ hasText: 'develop' }).first();
+  const nonHeadRow = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'develop' }).first();
   await nonHeadRow.hover();
-  await expect(nonHeadRow.locator('.action-btn.danger')).toBeVisible();
+  await expect(nonHeadRow.locator('[data-testid="delete-btn"]')).toBeVisible();
 });
 
 test('deletes a non-active branch', async ({ page }) => {
@@ -224,27 +224,27 @@ test('deletes a non-active branch', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  await expect(view.locator('.branch-row').filter({ hasText: 'e2e-delete-me' })).toBeVisible();
+  await expect(view.locator('[data-testid="branch-row"]').filter({ hasText: 'e2e-delete-me' })).toBeVisible();
 
   page.on('dialog', (dialog) => dialog.accept());
 
-  const row = view.locator('.branch-row:not(.head)').filter({ hasText: 'e2e-delete-me' }).first();
+  const row = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'e2e-delete-me' }).first();
   await row.hover();
-  await row.locator('.action-btn.danger').click();
+  await row.locator('[data-testid="delete-btn"]').click();
 
-  await expect(view.locator('.branch-row').filter({ hasText: 'e2e-delete-me' })).not.toBeVisible({ timeout: 5000 });
+  await expect(view.locator('[data-testid="branch-row"]').filter({ hasText: 'e2e-delete-me' })).not.toBeVisible({ timeout: 5000 });
 });
 
 test('toolbar shows updated branch name after checkout', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const developRow = view.locator('.branch-row:not(.head)').filter({ hasText: 'develop' }).first();
+  const developRow = view.locator('[data-testid="branch-row"]:not([data-head])').filter({ hasText: 'develop' }).first();
   await developRow.hover();
-  await developRow.locator('.action-btn', { hasText: 'Checkout' }).click();
+  await developRow.locator('[data-testid="checkout-btn"]', { hasText: 'Checkout' }).click();
 
-  await expect(view.locator('.branch-row.head').filter({ hasText: 'develop' })).toBeVisible({ timeout: 5000 });
-  await expect(page.locator('.toolbar-branch')).toContainText('develop', { timeout: 5000 });
+  await expect(view.locator('[data-testid="branch-row"][data-head]').filter({ hasText: 'develop' })).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText('develop', { timeout: 5000 });
 
   checkoutDefaultBranch(repoDir);
 });
@@ -253,8 +253,8 @@ test('active branch has no delete button', async ({ page }) => {
   await gotoBranchesView(page);
   const view = page.locator('branches-view');
 
-  const headRow = view.locator('.branch-row.head').first();
+  const headRow = view.locator('[data-testid="branch-row"][data-head]').first();
   await headRow.hover();
 
-  await expect(headRow.locator('.action-btn.danger')).not.toBeVisible();
+  await expect(headRow.locator('[data-testid="delete-btn"]')).not.toBeVisible();
 });

--- a/src/ghGPT.Frontend/e2e/changes-view.spec.ts
+++ b/src/ghGPT.Frontend/e2e/changes-view.spec.ts
@@ -42,21 +42,21 @@ test.beforeEach(async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
 });
 
 test('shows modified file in file list', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  await expect(changesView.locator('.file-entry').filter({ hasText: 'README.md' })).toBeVisible();
-  await expect(changesView.locator('.list-header').filter({ hasText: 'Änderungen' })).toBeVisible();
+  await expect(changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' })).toBeVisible();
+  await expect(changesView.locator('[data-testid="file-list-header"]').filter({ hasText: 'Änderungen' })).toBeVisible();
 });
 
 test('shows diff when clicking a modified file', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first().click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
-  await expect(changesView.locator('.diff-line.added')).not.toHaveCount(0);
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first().click();
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
+  await expect(changesView.locator('[data-testid="diff-line"][data-type="added"]')).not.toHaveCount(0);
 });
 
 test('shows diff when clicking a new untracked file', async ({ page }) => {
@@ -65,34 +65,34 @@ test('shows diff when clicking a new untracked file', async ({ page }) => {
 
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
 
   const changesView = page.locator('changes-view');
   await changesView.waitFor();
-  await expect(changesView.locator('.file-entry').filter({ hasText: fileName })).toBeVisible({ timeout: 5000 });
+  await expect(changesView.locator('[data-testid="file-entry"]').filter({ hasText: fileName })).toBeVisible({ timeout: 5000 });
 
-  await changesView.locator('.file-entry').filter({ hasText: fileName }).first().click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
-  await expect(changesView.locator('.diff-line.added')).not.toHaveCount(0);
-  await expect(changesView.locator('.diff-line-content').filter({ hasText: `+new file content ${modCounter}` })).toBeVisible();
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: fileName }).first().click();
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
+  await expect(changesView.locator('[data-testid="diff-line"][data-type="added"]')).not.toHaveCount(0);
+  await expect(changesView.locator('[data-testid="diff-line-content"]').filter({ hasText: `+new file content ${modCounter}` })).toBeVisible();
 });
 
 test('stages a file via checkbox', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  const entry = changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first();
+  const entry = changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first();
   const checkbox = entry.locator('input[type="checkbox"]');
 
   await expect(checkbox).not.toBeChecked();
   await checkbox.click();
   await expect(checkbox).toBeChecked({ timeout: 5000 });
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (1');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1');
 });
 
 test('unstages a file via checkbox', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  const entry = changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first();
+  const entry = changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first();
   const checkbox = entry.locator('input[type="checkbox"]');
-  const commitButton = changesView.locator('.commit-btn');
+  const commitButton = changesView.locator('[data-testid="commit-btn"]');
 
   await checkbox.click();
   await expect(checkbox).toBeChecked({ timeout: 5000 });
@@ -105,13 +105,13 @@ test('unstages a file via checkbox', async ({ page }) => {
 
 test('diff shows line numbers for both removed and added lines', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first().click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first().click();
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
 
-  const removedLine = changesView.locator('.diff-line.removed');
+  const removedLine = changesView.locator('[data-testid="diff-line"][data-type="removed"]');
   await expect(removedLine).toHaveCount(1);
 
-  const nums = removedLine.locator('.diff-line-num');
+  const nums = removedLine.locator('[data-testid="diff-line-num"]');
   const oldNum = await nums.nth(0).textContent();
   const newNum = await nums.nth(1).textContent();
   expect(oldNum?.trim()).not.toBe('');
@@ -120,44 +120,44 @@ test('diff shows line numbers for both removed and added lines', async ({ page }
 
 test('commit button is disabled when nothing is staged', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  await expect(changesView.locator('.commit-btn')).toBeDisabled();
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toBeDisabled();
 });
 
 test('commit button is disabled when message is empty', async ({ page }) => {
   const changesView = page.locator('changes-view');
-  const entry = changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first();
+  const entry = changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first();
   await entry.locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (1');
-  await expect(changesView.locator('.commit-btn')).toBeDisabled();
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toBeDisabled();
 });
 
 test('commit creates a new commit and clears staged files', async ({ page }) => {
   const changesView = page.locator('changes-view');
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first()
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (1');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1');
 
-  await changesView.locator('.commit-input[type="text"]').fill('test: commit from e2e');
-  await changesView.locator('.commit-btn').click();
+  await changesView.locator('[data-testid="commit-input"][type="text"]').fill('test: commit from e2e');
+  await changesView.locator('[data-testid="commit-btn"]').click();
 
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (0', { timeout: 5000 });
-  await expect(changesView.locator('.commit-input[type="text"]')).toHaveValue('');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (0', { timeout: 5000 });
+  await expect(changesView.locator('[data-testid="commit-input"][type="text"]')).toHaveValue('');
 });
 
 test('commit appears in history after creating it', async ({ page }) => {
   const changesView = page.locator('changes-view');
   const commitTitle = `test: history commit ${modCounter}`;
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first()
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (1');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1');
 
-  await changesView.locator('.commit-input[type="text"]').fill(commitTitle);
-  await changesView.locator('.commit-btn').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (0', { timeout: 5000 });
+  await changesView.locator('[data-testid="commit-input"][type="text"]').fill(commitTitle);
+  await changesView.locator('[data-testid="commit-btn"]').click();
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (0', { timeout: 5000 });
 
-  await page.locator('.nav-item').filter({ hasText: 'History' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'History' }).first().click();
   const historyView = page.locator('history-view');
   await historyView.waitFor();
   await expect(historyView).toContainText(commitTitle, { timeout: 5000 });
@@ -171,44 +171,44 @@ test('commit works when only deleted files are staged', async ({ page }) => {
 
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
 
-  await changesView.locator('.file-entry').filter({ hasText: 'main.ts' }).first()
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'main.ts' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (1', { timeout: 5000 });
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1', { timeout: 5000 });
 
-  await changesView.locator('.commit-input[type="text"]').fill('chore: remove main.ts');
-  await expect(changesView.locator('.commit-btn')).not.toBeDisabled();
-  await changesView.locator('.commit-btn').click();
-  await expect(changesView.locator('.commit-btn')).toContainText('Commit (0', { timeout: 5000 });
+  await changesView.locator('[data-testid="commit-input"][type="text"]').fill('chore: remove main.ts');
+  await expect(changesView.locator('[data-testid="commit-btn"]')).not.toBeDisabled();
+  await changesView.locator('[data-testid="commit-btn"]').click();
+  await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (0', { timeout: 5000 });
 });
 
 test('diff stays visible after toggling checkbox', async ({ page }) => {
   const changesView = page.locator('changes-view');
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first().click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first().click();
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first()
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first()
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
 });
 
 test('clears diff when switching to a different repository', async ({ page }) => {
   const changesView = page.locator('changes-view');
 
-  await changesView.locator('.file-entry').filter({ hasText: 'README.md' }).first().click();
-  await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+  await changesView.locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first().click();
+  await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
 
-  await page.locator('.repo-item').filter({ hasText: /ghgpt-test/ }).last().click();
+  await page.locator('[data-testid="repo-item"]').filter({ hasText: /ghgpt-test/ }).last().click();
 
-  await expect(changesView.locator('.diff-content')).not.toBeVisible({ timeout: 3000 });
-  await expect(changesView.locator('.diff-placeholder')).toBeVisible();
+  await expect(changesView.locator('[data-testid="diff-content"]')).not.toBeVisible({ timeout: 3000 });
+  await expect(changesView.locator('[data-testid="diff-placeholder"]')).toBeVisible();
 });
 
 test.describe('partial staging', () => {
@@ -223,15 +223,15 @@ test.describe('partial staging', () => {
     modifyFile(repoDir, 'partial.txt', 'Zeile A\nZeile NEU_1\nZeile B\nZeile NEU_2\nZeile C\n');
     await page.reload();
     await page.locator('app-shell').waitFor();
-    await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+    await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
     await page.locator('changes-view').waitFor();
-    await page.locator('changes-view .file-entry').filter({ hasText: 'partial.txt' }).first().click();
-    await expect(page.locator('changes-view .diff-content')).toBeVisible({ timeout: 5000 });
+    await page.locator('changes-view [data-testid="file-entry"]').filter({ hasText: 'partial.txt' }).first().click();
+    await expect(page.locator('changes-view [data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
   });
 
   test('checking one line stages it and keeps other line checkboxes visible', async ({ page }) => {
     const changesView = page.locator('changes-view');
-    const lineChecks = changesView.locator('.diff-line.added .diff-line-check input');
+    const lineChecks = changesView.locator('[data-testid="diff-line"][data-type="added"] [data-testid="diff-line-check"] input');
 
     await expect(lineChecks).toHaveCount(2);
     await expect(lineChecks.nth(0)).not.toBeChecked();
@@ -239,23 +239,23 @@ test.describe('partial staging', () => {
 
     await lineChecks.nth(0).click();
 
-    await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+    await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
     await expect(lineChecks).toHaveCount(2);
     await expect(lineChecks.nth(0)).toBeChecked();
     await expect(lineChecks.nth(1)).not.toBeChecked();
-    await expect(changesView.locator('.commit-btn')).toContainText('Commit (1', { timeout: 5000 });
+    await expect(changesView.locator('[data-testid="commit-btn"]')).toContainText('Commit (1', { timeout: 5000 });
   });
 
   test('checking a second line after the first succeeds without losing the diff', async ({ page }) => {
     const changesView = page.locator('changes-view');
-    const lineChecks = changesView.locator('.diff-line.added .diff-line-check input');
+    const lineChecks = changesView.locator('[data-testid="diff-line"][data-type="added"] [data-testid="diff-line-check"] input');
 
     await lineChecks.nth(0).click();
     await expect(lineChecks.nth(0)).toBeChecked({ timeout: 5000 });
 
     await lineChecks.nth(1).click();
 
-    await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+    await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
     await expect(lineChecks).toHaveCount(2);
     await expect(lineChecks.nth(0)).toBeChecked();
     await expect(lineChecks.nth(1)).toBeChecked();
@@ -263,7 +263,7 @@ test.describe('partial staging', () => {
 
   test('unchecking a staged line unstages only that line in the same diff view', async ({ page }) => {
     const changesView = page.locator('changes-view');
-    const lineChecks = changesView.locator('.diff-line.added .diff-line-check input');
+    const lineChecks = changesView.locator('[data-testid="diff-line"][data-type="added"] [data-testid="diff-line-check"] input');
 
     await lineChecks.nth(0).click();
     await lineChecks.nth(1).click();
@@ -272,7 +272,7 @@ test.describe('partial staging', () => {
 
     await lineChecks.nth(0).click();
 
-    await expect(changesView.locator('.diff-content')).toBeVisible({ timeout: 5000 });
+    await expect(changesView.locator('[data-testid="diff-content"]')).toBeVisible({ timeout: 5000 });
     await expect(lineChecks).toHaveCount(2);
     await expect(lineChecks.nth(0)).not.toBeChecked();
     await expect(lineChecks.nth(1)).toBeChecked();
@@ -280,8 +280,8 @@ test.describe('partial staging', () => {
 
   test('context lines have no checkbox', async ({ page }) => {
     const changesView = page.locator('changes-view');
-    const contextLine = changesView.locator('.diff-line:not(.added):not(.removed)').first();
+    const contextLine = changesView.locator('[data-testid="diff-line"][data-type="context"]').first();
 
-    await expect(contextLine.locator('.diff-line-check input')).toHaveCount(0);
+    await expect(contextLine.locator('[data-testid="diff-line-check"] input')).toHaveCount(0);
   });
 });

--- a/src/ghGPT.Frontend/e2e/git-toolbar-operations.spec.ts
+++ b/src/ghGPT.Frontend/e2e/git-toolbar-operations.spec.ts
@@ -76,10 +76,10 @@ test('fetch updates behind indicator in branch dropdown and pull button', async 
     return status;
   }).toMatch(/behind 1|hinterher 1/i);
 
-  await expect(page.locator('.git-overlay')).toHaveCount(0);
+  await expect(page.locator('[data-testid="git-overlay"]')).toHaveCount(0);
   await expect(page.getByRole('button', { name: /Pull/i })).toContainText('↓1');
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-item.active .branch-dropdown-behind')).toContainText('↓1');
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-item"][data-active] [data-testid="branch-dropdown-behind"]')).toContainText('↓1');
 });
 
 test('pull updates the working tree with remote changes', async ({ page }) => {
@@ -94,8 +94,8 @@ test('pull updates the working tree with remote changes', async ({ page }) => {
   await page.getByRole('button', { name: /Pull/i }).click();
 
   await expect.poll(() => readLocalFile(current, 'README.md')).toContain('Pulled from remote');
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-item.active .branch-dropdown-behind')).toHaveCount(0);
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-item"][data-active] [data-testid="branch-dropdown-behind"]')).toHaveCount(0);
 });
 
 test('push uploads a local commit to the remote', async ({ page }) => {
@@ -130,7 +130,7 @@ test('pull shows merge conflict error in overlay', async ({ page }) => {
   await gotoRepo(page, current);
   await page.getByRole('button', { name: /Pull/i }).click();
 
-  await expect(page.locator('.git-overlay')).toBeVisible();
-  await expect(page.locator('.git-overlay-status.error')).toContainText(/Merge-Konflikt/i);
-  await expect(page.locator('.git-overlay-log')).toContainText(/CONFLICT|KONFLIKT|Automatic merge failed|Automatischer Merge fehlgeschlagen/i);
+  await expect(page.locator('[data-testid="git-overlay"]')).toBeVisible();
+  await expect(page.locator('[data-testid="git-overlay-status"][data-error]')).toContainText(/Merge-Konflikt/i);
+  await expect(page.locator('[data-testid="git-overlay-log"]')).toContainText(/CONFLICT|KONFLIKT|Automatic merge failed|Automatischer Merge fehlgeschlagen/i);
 });

--- a/src/ghGPT.Frontend/e2e/history-view-large.spec.ts
+++ b/src/ghGPT.Frontend/e2e/history-view-large.spec.ts
@@ -31,24 +31,24 @@ test('loads additional commit pages while keeping the rendered DOM small', async
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  await page.locator('.nav-item').filter({ hasText: 'History' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'History' }).first().click();
   const historyView = page.locator('history-view');
   await historyView.waitFor();
 
   await expect(historyView).toContainText('perf: commit 105');
-  await expect(historyView.locator('.footer-hint')).toContainText('Weitere Commits', { timeout: 5000 });
+  await expect(historyView.locator('[data-testid="footer-hint"]')).toContainText('Weitere Commits', { timeout: 5000 });
 
-  const initialRenderedCount = await historyView.locator('.list-entry').count();
+  const initialRenderedCount = await historyView.locator('[data-testid="commit-entry"]').count();
   expect(initialRenderedCount).toBeLessThan(40);
 
-  const listScroll = historyView.locator('.list-scroll');
+  const listScroll = historyView.locator('[data-testid="commit-list-scroll"]');
   await listScroll.evaluate((element: HTMLElement) => {
     element.scrollTop = element.scrollHeight;
   });
 
-  await expect(historyView.locator('.footer-hint')).toContainText('106 Commits geladen', { timeout: 5000 });
+  await expect(historyView.locator('[data-testid="footer-hint"]')).toContainText('106 Commits geladen', { timeout: 5000 });
   await expect(historyView).toContainText('perf: commit 1', { timeout: 5000 });
 
-  const renderedCountAfterPaging = await historyView.locator('.list-entry').count();
+  const renderedCountAfterPaging = await historyView.locator('[data-testid="commit-entry"]').count();
   expect(renderedCountAfterPaging).toBeLessThan(50);
 });

--- a/src/ghGPT.Frontend/e2e/history-view.spec.ts
+++ b/src/ghGPT.Frontend/e2e/history-view.spec.ts
@@ -32,15 +32,15 @@ test('shows commit history and commit detail diff', async ({ page }) => {
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  await page.locator('.nav-item').filter({ hasText: 'History' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'History' }).first().click();
   const historyView = page.locator('history-view');
   await historyView.waitFor();
 
   await expect(historyView).toContainText('master');
   await expect(historyView).toContainText('feat: second history commit');
 
-  await historyView.locator('.list-entry').filter({ hasText: 'feat: second history commit' }).first().click();
-  await expect(historyView.locator('.detail-title')).toContainText('feat: second history commit');
-  await expect(historyView.locator('.file-item').filter({ hasText: 'README.md' })).toBeVisible();
-  await expect(historyView.locator('.diff-panel')).toContainText('+Zweiter Stand');
+  await historyView.locator('[data-testid="commit-entry"]').filter({ hasText: 'feat: second history commit' }).first().click();
+  await expect(historyView.locator('[data-testid="commit-detail-title"]')).toContainText('feat: second history commit');
+  await expect(historyView.locator('[data-testid="commit-file-item"]').filter({ hasText: 'README.md' })).toBeVisible();
+  await expect(historyView.locator('[data-testid="diff-panel"]')).toContainText('+Zweiter Stand');
 });

--- a/src/ghGPT.Frontend/e2e/remove-repo.spec.ts
+++ b/src/ghGPT.Frontend/e2e/remove-repo.spec.ts
@@ -33,7 +33,7 @@ test('remove button is hidden by default', async ({ page }) => {
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  const removeBtn = page.locator('.repo-item').first().locator('.repo-remove-btn');
+  const removeBtn = page.locator('[data-testid="repo-item"]').first().locator('[data-testid="repo-remove-btn"]');
   await expect(removeBtn).toBeHidden();
 });
 
@@ -43,9 +43,9 @@ test('remove button becomes visible on repo-item hover', async ({ page }) => {
   await page.reload();
   await page.locator('app-shell').waitFor();
 
-  const repoItem = page.locator('.repo-item').first();
+  const repoItem = page.locator('[data-testid="repo-item"]').first();
   await repoItem.hover();
-  await expect(repoItem.locator('.repo-remove-btn')).toBeVisible();
+  await expect(repoItem.locator('[data-testid="repo-remove-btn"]')).toBeVisible();
 });
 
 test('clicking remove button removes repo from sidebar', async ({ page }) => {
@@ -58,13 +58,13 @@ test('clicking remove button removes repo from sidebar', async ({ page }) => {
     await page.reload();
     await page.locator('app-shell').waitFor();
 
-    const countBefore = await page.locator('.repo-item').count();
+    const countBefore = await page.locator('[data-testid="repo-item"]').count();
 
-    const targetItem = page.locator('.repo-item').last();
+    const targetItem = page.locator('[data-testid="repo-item"]').last();
     await targetItem.hover();
-    await targetItem.locator('.repo-remove-btn').click();
+    await targetItem.locator('[data-testid="repo-remove-btn"]').click();
 
-    await expect(page.locator('.repo-item')).toHaveCount(countBefore - 1, { timeout: 3000 });
+    await expect(page.locator('[data-testid="repo-item"]')).toHaveCount(countBefore - 1, { timeout: 3000 });
   } finally {
     await deleteRepo(id).catch(() => {});
     removeTempRepo(dir);
@@ -83,13 +83,13 @@ test('removing active repo switches active state to another repo', async ({ page
     await page.reload();
     await page.locator('app-shell').waitFor();
 
-    const activeItem = page.locator('.repo-item.active');
+    const activeItem = page.locator('[data-testid="repo-item"][data-active]');
     await activeItem.hover();
-    await activeItem.locator('.repo-remove-btn').click();
+    await activeItem.locator('[data-testid="repo-remove-btn"]').click();
 
     // Another repo should now be active
-    await expect(page.locator('.repo-item.active')).toHaveCount(1, { timeout: 3000 });
-    await expect(page.locator('.repo-item.active').locator('.repo-name')).not.toHaveText('');
+    await expect(page.locator('[data-testid="repo-item"][data-active]')).toHaveCount(1, { timeout: 3000 });
+    await expect(page.locator('[data-testid="repo-item"][data-active]').locator('[data-testid="repo-name"]')).not.toHaveText('');
   } finally {
     await deleteRepo(id1).catch(() => {});
     await deleteRepo(id2).catch(() => {});
@@ -108,15 +108,15 @@ test('removing non-active repo does not change active repo', async ({ page }) =>
     await page.reload();
     await page.locator('app-shell').waitFor();
 
-    const activeNameBefore = await page.locator('.repo-item.active .repo-name').textContent();
+    const activeNameBefore = await page.locator('[data-testid="repo-item"][data-active] [data-testid="repo-name"]').textContent();
 
     // Remove the last (non-active) item
-    const lastItem = page.locator('.repo-item').last();
+    const lastItem = page.locator('[data-testid="repo-item"]').last();
     await lastItem.hover();
-    await lastItem.locator('.repo-remove-btn').click();
+    await lastItem.locator('[data-testid="repo-remove-btn"]').click();
 
-    await expect(page.locator('.repo-item.active')).toHaveCount(1, { timeout: 3000 });
-    await expect(page.locator('.repo-item.active .repo-name')).toHaveText(activeNameBefore!);
+    await expect(page.locator('[data-testid="repo-item"][data-active]')).toHaveCount(1, { timeout: 3000 });
+    await expect(page.locator('[data-testid="repo-item"][data-active] [data-testid="repo-name"]')).toHaveText(activeNameBefore!);
   } finally {
     await deleteRepo(id).catch(() => {});
     removeTempRepo(dir);
@@ -134,12 +134,12 @@ test('removed repo files still exist on disk', async ({ page }) => {
     await page.reload();
     await page.locator('app-shell').waitFor();
 
-    const lastItem = page.locator('.repo-item').last();
+    const lastItem = page.locator('[data-testid="repo-item"]').last();
     await lastItem.hover();
-    await lastItem.locator('.repo-remove-btn').click();
+    await lastItem.locator('[data-testid="repo-remove-btn"]').click();
 
-    await expect(page.locator('.repo-item')).not.toHaveCount(
-      await page.locator('.repo-item').count() + 1,
+    await expect(page.locator('[data-testid="repo-item"]')).not.toHaveCount(
+      await page.locator('[data-testid="repo-item"]').count() + 1,
       { timeout: 3000 }
     );
 

--- a/src/ghGPT.Frontend/e2e/screenshots.spec.ts
+++ b/src/ghGPT.Frontend/e2e/screenshots.spec.ts
@@ -57,7 +57,7 @@ test('02 - Sidebar mit Repositories', async ({ page }) => {
 test('03 - Repo-Dialog: Clone Tab', async ({ page }) => {
   await page.goto('/');
   await page.locator('app-shell').waitFor();
-  await page.locator('.add-btn').first().click();
+  await page.locator('[data-testid="add-repo-btn"]').first().click();
   await page.locator('repo-dialog').waitFor({ state: 'attached' });
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '03-dialog-clone.png'), fullPage: true });
 });
@@ -65,7 +65,7 @@ test('03 - Repo-Dialog: Clone Tab', async ({ page }) => {
 test('04 - Repo-Dialog: Import Tab', async ({ page }) => {
   await page.goto('/');
   await page.locator('app-shell').waitFor();
-  await page.locator('.add-btn').first().click();
+  await page.locator('[data-testid="add-repo-btn"]').first().click();
   await page.locator('repo-dialog').waitFor({ state: 'attached' });
   await page.locator('repo-dialog').locator('button', { hasText: 'Importieren' }).first().click();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '04-dialog-import.png'), fullPage: true });
@@ -74,7 +74,7 @@ test('04 - Repo-Dialog: Import Tab', async ({ page }) => {
 test('05 - Repo-Dialog: Erstellen Tab', async ({ page }) => {
   await page.goto('/');
   await page.locator('app-shell').waitFor();
-  await page.locator('.add-btn').first().click();
+  await page.locator('[data-testid="add-repo-btn"]').first().click();
   await page.locator('repo-dialog').waitFor({ state: 'attached' });
   await page.locator('repo-dialog').locator('button', { hasText: 'Erstellen' }).first().click();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '05-dialog-create.png'), fullPage: true });
@@ -86,7 +86,7 @@ test('06 - Changes View: Unstaged Änderungen', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '06-changes-unstaged.png'), fullPage: true });
 });
@@ -97,10 +97,10 @@ test('07 - Changes View: Diff einer Datei', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
-  await page.locator('changes-view').locator('.file-entry').filter({ hasText: 'README.md' }).first().click();
-  await page.locator('changes-view').locator('.diff-content').waitFor({ timeout: 5000 });
+  await page.locator('changes-view').locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first().click();
+  await page.locator('changes-view').locator('[data-testid="diff-content"]').waitFor({ timeout: 5000 });
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '07-changes-diff.png'), fullPage: true });
 });
 
@@ -110,11 +110,11 @@ test('08 - Changes View: Datei gecheckt', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
-  await page.locator('changes-view').locator('.file-entry').filter({ hasText: 'README.md' }).first()
+  await page.locator('changes-view').locator('[data-testid="file-entry"]').filter({ hasText: 'README.md' }).first()
     .locator('input[type="checkbox"]').click();
-  await expect(page.locator('changes-view').locator('.commit-btn')).toContainText('Commit (1', { timeout: 5000 });
+  await expect(page.locator('changes-view').locator('[data-testid="commit-btn"]')).toContainText('Commit (1', { timeout: 5000 });
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '08-changes-staged.png'), fullPage: true });
 });
 
@@ -124,13 +124,13 @@ test('09 - Changes View: Commit-Formular mit gemischten Änderungen', async ({ p
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
 
-  await page.locator('changes-view').locator('.list-header input[type="checkbox"]').click();
-  await expect(page.locator('changes-view').locator('.commit-btn')).toContainText(/Commit \([1-9]/, { timeout: 5000 });
+  await page.locator('changes-view').locator('[data-testid="file-list-header"] input[type="checkbox"]').click();
+  await expect(page.locator('changes-view').locator('[data-testid="commit-btn"]')).toContainText(/Commit \([1-9]/, { timeout: 5000 });
 
-  await page.locator('changes-view').locator('.commit-input[type="text"]').fill('feat: neue Funktion');
+  await page.locator('changes-view').locator('[data-testid="commit-input"][type="text"]').fill('feat: neue Funktion');
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '09-commit-form.png'), fullPage: true });
 });
 
@@ -139,7 +139,7 @@ test('10 - Branches View: Branch-Übersicht', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '10-branches-overview.png'), fullPage: true });
 });
@@ -149,11 +149,11 @@ test('11 - Branches View: Neuer Branch Dialog', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  await page.locator('branches-view .dialog').waitFor();
-  await page.locator('branches-view .dialog input[type="text"]').fill('feature/mein-feature');
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  await page.locator('branches-view [data-testid="new-branch-dialog"]').waitFor();
+  await page.locator('branches-view [data-testid="new-branch-dialog"] input[type="text"]').fill('feature/mein-feature');
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '11-branches-new-dialog.png'), fullPage: true });
 });
 
@@ -162,9 +162,9 @@ test('12 - Branches View: Hover auf Branch-Zeile', async ({ page }) => {
   await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
-  await page.locator('branches-view .branch-row:not(.head)').first().hover();
+  await page.locator('branches-view [data-testid="branch-row"]:not([data-head])').first().hover();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '12-branches-row-hover.png'), fullPage: true });
 });
 
@@ -215,9 +215,9 @@ test('13 - Branches View: Übersicht mit Remote-Branches', async ({ page }) => {
   await setActiveRepo(remoteRepoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
-  await expect(page.locator('branches-view .section-title').filter({ hasText: /Remote/i })).toBeVisible();
+  await expect(page.locator('branches-view [data-testid="section-title"]').filter({ hasText: /Remote/i })).toBeVisible();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '13-branches-remote-overview.png'), fullPage: true });
 });
 
@@ -227,12 +227,12 @@ test('14 - Branches View: Neuer Branch Dialog mit Remote als Basis', async ({ pa
   await setActiveRepo(remoteRepoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
-  await page.locator('branches-view .btn-primary').filter({ hasText: 'Neuer Branch' }).click();
-  await page.locator('branches-view .dialog').waitFor();
-  await page.locator('branches-view .dialog input[type="text"]').fill('feature/from-remote');
-  await page.locator('branches-view .dialog select').selectOption({ label: 'origin/feature/remote-branch' });
+  await page.locator('branches-view [data-testid="new-branch-btn"]').click();
+  await page.locator('branches-view [data-testid="new-branch-dialog"]').waitFor();
+  await page.locator('branches-view [data-testid="new-branch-dialog"] input[type="text"]').fill('feature/from-remote');
+  await page.locator('branches-view [data-testid="new-branch-dialog"] select').selectOption({ label: 'origin/feature/remote-branch' });
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '14-branches-remote-new-dialog.png'), fullPage: true });
 });
 
@@ -242,9 +242,9 @@ test('15 - Branches View: Hover auf Remote-Branch-Zeile', async ({ page }) => {
   await setActiveRepo(remoteRepoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Branches' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Branches' }).first().click();
   await page.locator('branches-view').waitFor();
-  await page.locator('branches-view .branch-row').filter({ hasText: 'origin/feature/remote-branch' }).hover();
+  await page.locator('branches-view [data-testid="branch-row"]').filter({ hasText: 'origin/feature/remote-branch' }).hover();
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '15-branches-remote-row-hover.png'), fullPage: true });
 });
 
@@ -260,13 +260,13 @@ test('16 - Changes View: Partial Staging - Zeilen selektiert', async ({ page }) 
   await setActiveRepo(repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
 
-  await page.locator('changes-view .file-entry').filter({ hasText: 'partial-staging.txt' }).first().click();
-  await page.locator('changes-view .diff-content').waitFor({ timeout: 5000 });
+  await page.locator('changes-view [data-testid="file-entry"]').filter({ hasText: 'partial-staging.txt' }).first().click();
+  await page.locator('changes-view [data-testid="diff-content"]').waitFor({ timeout: 5000 });
 
-  const lineChecks = page.locator('changes-view .diff-line.added .diff-line-check input');
+  const lineChecks = page.locator('changes-view [data-testid="diff-line"][data-type="added"] [data-testid="diff-line-check"] input');
   await expect(lineChecks).toHaveCount(3);
   await lineChecks.nth(0).click();
   await expect(lineChecks.nth(0)).toBeChecked({ timeout: 5000 });
@@ -285,13 +285,13 @@ test('17 - Changes View: Partial Staging - Nach dem Stagen', async ({ page }) =>
   await setActiveRepo(repoId);
   await page.reload();
   await page.locator('app-shell').waitFor();
-  await page.locator('.nav-item').filter({ hasText: 'Änderungen' }).first().click();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Änderungen' }).first().click();
   await page.locator('changes-view').waitFor();
 
-  await page.locator('changes-view .file-entry').filter({ hasText: 'partial-staging.txt' }).first().click();
-  await page.locator('changes-view .diff-content').waitFor({ timeout: 5000 });
+  await page.locator('changes-view [data-testid="file-entry"]').filter({ hasText: 'partial-staging.txt' }).first().click();
+  await page.locator('changes-view [data-testid="diff-content"]').waitFor({ timeout: 5000 });
 
-  const lineChecks = page.locator('changes-view .diff-line.added .diff-line-check input');
+  const lineChecks = page.locator('changes-view [data-testid="diff-line"][data-type="added"] [data-testid="diff-line-check"] input');
   await expect(lineChecks).toHaveCount(3);
   await lineChecks.nth(0).click();
   await expect(lineChecks.nth(0)).toBeChecked({ timeout: 5000 });
@@ -313,7 +313,7 @@ test('18 - Toolbar: Pull-Button mit Rueckstand', async ({ page }) => {
   await page.reload();
   await page.locator('app-shell').waitFor();
   await page.getByRole('button', { name: /Fetch/i }).click();
-  await expect(page.locator('.git-overlay')).toHaveCount(0);
+  await expect(page.locator('[data-testid="git-overlay"]')).toHaveCount(0);
   await expect(page.getByRole('button', { name: /Pull/i })).toContainText('↓1');
 
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '18-toolbar-pull-behind.png'), fullPage: true });

--- a/src/ghGPT.Frontend/e2e/toolbar-branch-dropdown.spec.ts
+++ b/src/ghGPT.Frontend/e2e/toolbar-branch-dropdown.spec.ts
@@ -44,74 +44,74 @@ async function gotoApp(page: import('@playwright/test').Page) {
 
 test('toolbar branch button opens dropdown', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown')).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).toBeVisible();
 });
 
 test('dropdown shows current branch with checkmark', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  const activeItem = page.locator('.branch-dropdown-item.active');
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  const activeItem = page.locator('[data-testid="branch-dropdown-item"][data-active]');
   await expect(activeItem).toBeVisible();
-  await expect(activeItem.locator('.check')).toContainText('✓');
+  await expect(activeItem.locator('[data-testid="branch-check"]')).toContainText('✓');
 });
 
 test('dropdown shows local branches', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-item').filter({ hasText: /master|main/ })).toBeVisible();
-  await expect(page.locator('.branch-dropdown-item').filter({ hasText: 'feature/dropdown-test' })).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-item"]').filter({ hasText: /master|main/ })).toBeVisible();
+  await expect(page.locator('[data-testid="branch-dropdown-item"]').filter({ hasText: 'feature/dropdown-test' })).toBeVisible();
 });
 
 test('dropdown shows local branches section title', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-section').filter({ hasText: /Lokale/i })).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-section"]').filter({ hasText: /Lokale/i })).toBeVisible();
 });
 
 test('dropdown closes on second click of toolbar button', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown')).toBeVisible();
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown')).not.toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).not.toBeVisible();
 });
 
 test('dropdown closes on click outside', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown')).toBeVisible();
-  await page.locator('.sidebar').click();
-  await expect(page.locator('.branch-dropdown')).not.toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).toBeVisible();
+  await page.locator('[data-testid="sidebar"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).not.toBeVisible();
 });
 
 test('dropdown has "Branch verwalten" footer link', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-footer')).toBeVisible();
-  await expect(page.locator('.branch-dropdown-footer')).toContainText('Branch verwalten');
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-footer"]')).toBeVisible();
+  await expect(page.locator('[data-testid="branch-dropdown-footer"]')).toContainText('Branch verwalten');
 });
 
 test('"Branch verwalten" navigates to branches view', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
-  await page.locator('.branch-dropdown-footer').click();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await page.locator('[data-testid="branch-dropdown-footer"]').click();
   await page.locator('branches-view').waitFor();
   await expect(page.locator('branches-view')).toBeVisible();
-  await expect(page.locator('.branch-dropdown')).not.toBeVisible();
+  await expect(page.locator('[data-testid="branch-dropdown"]')).not.toBeVisible();
 });
 
 // --- Checkout ---
 
 test('clicking a non-active branch checks it out', async ({ page }) => {
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
+  await page.locator('[data-testid="toolbar-branch"]').click();
 
-  const featureItem = page.locator('.branch-dropdown-item:not(.active)').filter({ hasText: 'feature/dropdown-test' });
+  const featureItem = page.locator('[data-testid="branch-dropdown-item"]:not([data-active])').filter({ hasText: 'feature/dropdown-test' });
   await featureItem.click();
 
-  await expect(page.locator('.toolbar-branch')).toContainText('feature/dropdown-test', { timeout: 5000 });
-  await expect(page.locator('.branch-dropdown')).not.toBeVisible();
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText('feature/dropdown-test', { timeout: 5000 });
+  await expect(page.locator('[data-testid="branch-dropdown"]')).not.toBeVisible();
 
   checkoutDefaultBranch(repoDir);
 });
@@ -120,21 +120,21 @@ test('toolbar branch name updates after checkout', async ({ page }) => {
   await gotoApp(page);
 
   // checkout via dropdown zu feature-branch
-  await page.locator('.toolbar-branch').click();
-  await page.locator('.branch-dropdown-item:not(.active)').filter({ hasText: 'feature/dropdown-test' }).click();
-  await expect(page.locator('.toolbar-branch')).toContainText('feature/dropdown-test', { timeout: 5000 });
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await page.locator('[data-testid="branch-dropdown-item"]:not([data-active])').filter({ hasText: 'feature/dropdown-test' }).click();
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText('feature/dropdown-test', { timeout: 5000 });
 
   // checkout via dropdown zurück zu master/main
-  await page.locator('.toolbar-branch').click();
-  await page.locator('.branch-dropdown-item:not(.active)').filter({ hasText: /master|main/ }).click();
-  await expect(page.locator('.toolbar-branch')).toContainText(/master|main/, { timeout: 5000 });
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await page.locator('[data-testid="branch-dropdown-item"]:not([data-active])').filter({ hasText: /master|main/ }).click();
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText(/master|main/, { timeout: 5000 });
 });
 
 test('shows alert when checking out with uncommitted changes', async ({ page }) => {
   modifyFile(repoDir, 'dirty.txt', 'uncommitted\n');
 
   await gotoApp(page);
-  await page.locator('.toolbar-branch').click();
+  await page.locator('[data-testid="toolbar-branch"]').click();
 
   let alertMessage = '';
   page.on('dialog', async (dialog) => {
@@ -142,7 +142,7 @@ test('shows alert when checking out with uncommitted changes', async ({ page }) 
     await dialog.accept();
   });
 
-  await page.locator('.branch-dropdown-item:not(.active)').filter({ hasText: 'feature/dropdown-test' }).click();
+  await page.locator('[data-testid="branch-dropdown-item"]:not([data-active])').filter({ hasText: 'feature/dropdown-test' }).click();
   await page.waitForEvent('dialog', { timeout: 5000 });
   expect(alertMessage).toMatch(/uncommitted|Änderungen/i);
 
@@ -180,23 +180,23 @@ async function gotoAppRemote(page: import('@playwright/test').Page) {
 
 test('dropdown shows remote branches section', async ({ page }) => {
   await gotoAppRemote(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-section').filter({ hasText: /Remote/i })).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-section"]').filter({ hasText: /Remote/i })).toBeVisible();
 });
 
 test('dropdown shows remote branch with cloud icon', async ({ page }) => {
   await gotoAppRemote(page);
-  await page.locator('.toolbar-branch').click();
-  await expect(page.locator('.branch-dropdown-item').filter({ hasText: /☁.*origin\/feature\/remote-branch/ })).toBeVisible();
+  await page.locator('[data-testid="toolbar-branch"]').click();
+  await expect(page.locator('[data-testid="branch-dropdown-item"]').filter({ hasText: /☁.*origin\/feature\/remote-branch/ })).toBeVisible();
 });
 
 test('checkout remote branch from dropdown creates local tracking branch', async ({ page }) => {
   await gotoAppRemote(page);
-  await page.locator('.toolbar-branch').click();
+  await page.locator('[data-testid="toolbar-branch"]').click();
 
-  await page.locator('.branch-dropdown-item').filter({ hasText: /origin\/feature\/remote-branch/ }).click();
+  await page.locator('[data-testid="branch-dropdown-item"]').filter({ hasText: /origin\/feature\/remote-branch/ }).click();
 
-  await expect(page.locator('.toolbar-branch')).toContainText('feature/remote-branch', { timeout: 5000 });
+  await expect(page.locator('[data-testid="toolbar-branch"]')).toContainText('feature/remote-branch', { timeout: 5000 });
 
   try { execSync('git checkout master', { cwd: remoteLocalDir, stdio: 'pipe' }); }
   catch { execSync('git checkout main', { cwd: remoteLocalDir, stdio: 'pipe' }); }

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -83,7 +83,7 @@ export class AppShell extends AppElement {
     const contentClass = `flex flex-col flex-1 overflow-hidden text-cat-text${isPadded ? ' p-4 overflow-auto' : ''}`;
     return html`
       <app-sidebar
-        class="sidebar"
+        data-testid="sidebar"
         .repos=${s.repos}
         .activeRepoId=${s.activeRepoId}
         .activeView=${this.activeView}

--- a/src/ghGPT.Frontend/src/components/branches-view.ts
+++ b/src/ghGPT.Frontend/src/components/branches-view.ts
@@ -86,23 +86,23 @@ export class BranchesView extends AppElement {
 
   private renderBranchRow(b: BranchInfo) {
     return html`
-      <div class="branch-row ${b.isHead ? 'head' : ''} group flex items-center gap-2 px-3 py-2 rounded-md border cursor-pointer transition-colors
+      <div data-testid="branch-row" ?data-head=${b.isHead} class="group flex items-center gap-2 px-3 py-2 rounded-md border cursor-pointer transition-colors
         ${b.isHead ? 'border-[#89b4fa33] bg-[#89b4fa11]' : 'border-transparent hover:bg-cat-overlay'}"
         @dblclick=${() => !b.isHead && this.checkout(b.name)}>
-        <span class="branch-icon text-sm shrink-0">${b.isRemote ? '☁' : '🌿'}</span>
+        <span data-testid="branch-icon" class="text-sm shrink-0">${b.isRemote ? '☁' : '🌿'}</span>
         <span class="text-sm flex-1 overflow-hidden text-ellipsis whitespace-nowrap
           ${b.isHead ? 'text-cat-blue font-medium' : 'text-cat-text'}">${b.name}</span>
-        ${b.isHead ? html`<span class="head-badge text-[0.65rem] bg-[#89b4fa33] text-cat-blue rounded px-1 shrink-0">HEAD</span>` : nothing}
+        ${b.isHead ? html`<span data-testid="head-badge" class="text-[0.65rem] bg-[#89b4fa33] text-cat-blue rounded px-1 shrink-0">HEAD</span>` : nothing}
         ${this.renderAheadBehind(b)}
         <div class="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
           ${!b.isHead ? html`
-            <button class="action-btn px-2 py-0.5 rounded border border-cat-muted bg-transparent text-cat-text text-xs cursor-pointer hover:bg-cat-muted"
+            <button data-testid="checkout-btn" class="px-2 py-0.5 rounded border border-cat-muted bg-transparent text-cat-text text-xs cursor-pointer hover:bg-cat-muted"
               @click=${(e: Event) => { e.stopPropagation(); this.checkout(b.name); }}>
               Checkout
             </button>
           ` : nothing}
           ${!b.isHead ? html`
-            <button class="action-btn danger px-2 py-0.5 rounded border border-cat-muted bg-transparent text-cat-red text-xs cursor-pointer hover:bg-cat-muted"
+            <button data-testid="delete-btn" class="px-2 py-0.5 rounded border border-cat-muted bg-transparent text-cat-red text-xs cursor-pointer hover:bg-cat-muted"
               @click=${(e: Event) => { e.stopPropagation(); this.deleteBranch(b.name); }}>
               ✕
             </button>
@@ -119,8 +119,8 @@ export class BranchesView extends AppElement {
 
     return html`
       <div class="flex items-center gap-2 px-4 py-3 border-b border-cat-border shrink-0">
-        <span class="toolbar-title text-sm font-semibold text-cat-text flex-1">Branches</span>
-        <button class="btn-primary px-3 py-1 rounded-md border border-cat-blue bg-cat-blue text-cat-base text-xs cursor-pointer hover:bg-cat-sapphire hover:border-cat-sapphire"
+        <span data-testid="toolbar-title" class="text-sm font-semibold text-cat-text flex-1">Branches</span>
+        <button data-testid="new-branch-btn" class="px-3 py-1 rounded-md border border-cat-blue bg-cat-blue text-cat-base text-xs cursor-pointer hover:bg-cat-sapphire hover:border-cat-sapphire"
           @click=${() => { this.showNewBranchDialog = true; this.newBranchStartPoint = localBranches.find(b => b.isHead)?.name ?? ''; }}>
           + Neuer Branch
         </button>
@@ -129,7 +129,7 @@ export class BranchesView extends AppElement {
       </div>
 
       <div class="flex-1 overflow-y-auto p-4">
-        <div class="section-title text-[0.7rem] uppercase tracking-widest text-cat-subtle mb-2">Lokale Branches</div>
+        <div data-testid="section-title" class="text-[0.7rem] uppercase tracking-widest text-cat-subtle mb-2">Lokale Branches</div>
         <div class="flex flex-col gap-0.5">
           ${localBranches.length > 0
             ? localBranches.map(b => this.renderBranchRow(b))
@@ -137,7 +137,7 @@ export class BranchesView extends AppElement {
         </div>
 
         ${remoteBranches.length > 0 ? html`
-          <div class="section-title text-[0.7rem] uppercase tracking-widest text-cat-subtle mb-2 mt-4">Remote Branches</div>
+          <div data-testid="section-title" class="text-[0.7rem] uppercase tracking-widest text-cat-subtle mb-2 mt-4">Remote Branches</div>
           <div class="flex flex-col gap-0.5">
             ${remoteBranches.map(b => this.renderBranchRow(b))}
           </div>
@@ -147,8 +147,8 @@ export class BranchesView extends AppElement {
       ${this.showNewBranchDialog ? html`
         <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-[100]"
           @click=${(e: Event) => { if (e.target === e.currentTarget) this.showNewBranchDialog = false; }}>
-          <div class="dialog bg-cat-surface border border-cat-border rounded-xl p-6 w-[420px] flex flex-col gap-4">
-            <div class="dialog-title text-base font-semibold text-cat-text">Neuen Branch erstellen</div>
+          <div data-testid="new-branch-dialog" class="bg-cat-surface border border-cat-border rounded-xl p-6 w-[420px] flex flex-col gap-4">
+            <div data-testid="dialog-title" class="text-base font-semibold text-cat-text">Neuen Branch erstellen</div>
 
             <div class="flex flex-col gap-1.5">
               <label class="text-xs text-cat-subtext">Branch-Name</label>
@@ -174,12 +174,12 @@ export class BranchesView extends AppElement {
               </select>
             </div>
 
-            ${this.dialogError ? html`<span class="error-msg text-cat-red text-xs">${this.dialogError}</span>` : nothing}
+            ${this.dialogError ? html`<span data-testid="error-msg" class="text-cat-red text-xs">${this.dialogError}</span>` : nothing}
 
             <div class="flex gap-2 justify-end">
               <button class="btn px-3 py-1.5 rounded-md border border-cat-muted bg-transparent text-cat-text text-sm cursor-pointer hover:bg-cat-overlay"
                 @click=${() => { this.showNewBranchDialog = false; this.dialogError = ''; }}>Abbrechen</button>
-              <button class="btn-primary px-3 py-1.5 rounded-md border border-cat-blue bg-cat-blue text-cat-base text-sm cursor-pointer hover:bg-cat-sapphire disabled:opacity-40 disabled:cursor-not-allowed"
+              <button data-testid="create-branch-btn" class="px-3 py-1.5 rounded-md border border-cat-blue bg-cat-blue text-cat-base text-sm cursor-pointer hover:bg-cat-sapphire disabled:opacity-40 disabled:cursor-not-allowed"
                 ?disabled=${this.loading} @click=${this.onCreateBranch}>
                 ${this.loading ? 'Erstelle…' : 'Erstellen'}
               </button>

--- a/src/ghGPT.Frontend/src/components/changes-view.ts
+++ b/src/ghGPT.Frontend/src/components/changes-view.ts
@@ -542,7 +542,7 @@ export class ChangesView extends AppElement {
 
   private renderDiff() {
     if (!this.selectedPath) {
-      return html`<div class="diff-placeholder flex items-center justify-center h-full text-cat-muted text-sm">Datei auswählen</div>`;
+      return html`<div data-testid="diff-placeholder" class="flex items-center justify-center h-full text-cat-muted text-sm">Datei auswählen</div>`;
     }
     if (this.diffError) {
       return html`<div class="flex items-center justify-center h-full text-sm text-cat-red">${this.diffError}</div>`;
@@ -552,17 +552,17 @@ export class ChangesView extends AppElement {
     }
 
     return html`
-      <div class="diff-content flex-1 overflow-auto p-0 font-mono text-[0.78rem]"
+      <div data-testid="diff-content" class="flex-1 overflow-auto p-0 font-mono text-[0.78rem]"
            style="background: linear-gradient(90deg, #202539 0, #202539 28px, transparent 28px)">
         ${this.combinedHunks.flatMap(hunk => hunk.lines.map(line => {
           const selectable = line.type !== 'context';
           const isChecked = selectable && this.stagedLineKeys.has(line.lineKey);
 
           return html`
-            <div class="diff-line ${line.type} flex leading-[1.5] whitespace-pre">
-              <span class="diff-line-num w-8 shrink-0 text-cat-muted select-none text-right pr-2">${line.oldNum}</span>
-              <span class="diff-line-num w-8 shrink-0 text-cat-muted select-none text-right pr-2">${line.newNum}</span>
-              <span class="diff-line-check w-5 shrink-0 flex items-center justify-center">
+            <div data-testid="diff-line" data-type=${line.type} class="flex leading-[1.5] whitespace-pre">
+              <span data-testid="diff-line-num" class="w-8 shrink-0 text-cat-muted select-none text-right pr-2">${line.oldNum}</span>
+              <span data-testid="diff-line-num" class="w-8 shrink-0 text-cat-muted select-none text-right pr-2">${line.newNum}</span>
+              <span data-testid="diff-line-check" class="w-5 shrink-0 flex items-center justify-center">
                 ${selectable ? html`
                   <input
                     type="checkbox"
@@ -573,7 +573,7 @@ export class ChangesView extends AppElement {
                       this.toggleLine(line.globalIndex, e.shiftKey);
                     }} />` : ''}
               </span>
-              <span class="diff-line-content flex-1 min-w-0 overflow-hidden">${line.content}</span>
+              <span data-testid="diff-line-content" class="flex-1 min-w-0 overflow-hidden">${line.content}</span>
             </div>`;
         }))}
       </div>`;
@@ -621,7 +621,7 @@ export class ChangesView extends AppElement {
     const statusColor = statusColorMap[entry.status] ?? 'text-cat-subtext';
 
     return html`
-      <div class="file-entry flex items-center gap-2 px-3 py-[0.3rem] cursor-pointer text-[0.8rem] text-cat-text select-none hover:bg-cat-overlay ${isSelected ? 'bg-cat-muted' : ''}"
+      <div data-testid="file-entry" class="flex items-center gap-2 px-3 py-[0.3rem] cursor-pointer text-[0.8rem] text-cat-text select-none hover:bg-cat-overlay ${isSelected ? 'bg-cat-muted' : ''}"
         @click=${() => this.selectFile(filePath)}>
         <input type="checkbox"
           class="cursor-pointer shrink-0 accent-cat-blue w-[14px] h-[14px]"
@@ -649,7 +649,7 @@ export class ChangesView extends AppElement {
 
     return html`
       <div class="w-[260px] min-w-[260px] flex flex-col border-r border-cat-border overflow-hidden">
-        <div class="list-header flex items-center gap-2 px-3 py-[0.4rem] text-[0.7rem] uppercase tracking-[0.08em] text-cat-subtle bg-cat-surface border-b border-cat-border shrink-0">
+        <div data-testid="file-list-header" class="flex items-center gap-2 px-3 py-[0.4rem] text-[0.7rem] uppercase tracking-[0.08em] text-cat-subtle bg-cat-surface border-b border-cat-border shrink-0">
           <input type="checkbox"
             class="cursor-pointer"
             .checked=${this.allChecked}
@@ -673,7 +673,8 @@ export class ChangesView extends AppElement {
           </button>
           ${this.aiStreamPreview ? html`<div class="text-[0.72rem] text-cat-blue italic min-h-[1em]">${this.aiStreamPreview}</div>` : ''}
           <input
-            class="commit-input bg-cat-base border border-cat-border rounded text-cat-text text-[0.8rem] px-2 py-[0.35rem] w-full box-border font-[inherit] focus:outline-none focus:border-cat-blue placeholder:text-cat-muted"
+            data-testid="commit-input"
+            class="bg-cat-base border border-cat-border rounded text-cat-text text-[0.8rem] px-2 py-[0.35rem] w-full box-border font-[inherit] focus:outline-none focus:border-cat-blue placeholder:text-cat-muted"
             type="text"
             placeholder="Commit-Titel (Pflichtfeld)"
             .value=${this.commitMessage}
@@ -686,7 +687,8 @@ export class ChangesView extends AppElement {
             @input=${(e: Event) => { this.commitDescription = (e.target as HTMLTextAreaElement).value; }}></textarea>
           ${this.commitError ? html`<div class="text-[0.72rem] text-cat-red">${this.commitError}</div>` : ''}
           <button
-            class="commit-btn bg-cat-blue border-none rounded text-cat-surface cursor-pointer text-[0.8rem] font-semibold px-3 py-[0.35rem] w-full disabled:bg-cat-overlay disabled:text-cat-muted disabled:cursor-default hover:enabled:bg-[#b4d0ff]"
+            data-testid="commit-btn"
+            class="bg-cat-blue border-none rounded text-cat-surface cursor-pointer text-[0.8rem] font-semibold px-3 py-[0.35rem] w-full disabled:bg-cat-overlay disabled:text-cat-muted disabled:cursor-default hover:enabled:bg-[#b4d0ff]"
             ?disabled=${!this.commitMessage.trim() || stagedCount === 0 || this.committing}
             @click=${this.doCommit}>
             ${this.committing ? 'Committing...' : `Commit (${stagedCount} Datei${stagedCount !== 1 ? 'en' : ''})`}
@@ -694,7 +696,7 @@ export class ChangesView extends AppElement {
         </div>
       </div>
 
-      <div class="diff-panel flex-1 flex flex-col overflow-hidden bg-cat-base relative">
+      <div data-testid="diff-panel" class="flex-1 flex flex-col overflow-hidden bg-cat-base relative">
         <div class="flex items-center gap-2 px-4 py-2 text-[0.8rem] text-cat-subtext border-b border-cat-border bg-cat-surface shrink-0 whitespace-nowrap overflow-hidden">
           <span class="flex-1 overflow-hidden text-ellipsis">${this.selectedPath || 'Kein Diff'}</span>
           <button

--- a/src/ghGPT.Frontend/src/components/git-operation-overlay.ts
+++ b/src/ghGPT.Frontend/src/components/git-operation-overlay.ts
@@ -16,12 +16,12 @@ export class GitOperationOverlay extends AppElement {
   render() {
     const statusClass = `text-xs ${this.error ? 'text-cat-red' : 'text-cat-subtle'}`;
     return html`
-      <div class="git-overlay fixed inset-0 bg-black/70 flex items-center justify-center z-[400] p-6">
+      <div data-testid="git-overlay" class="fixed inset-0 bg-black/70 flex items-center justify-center z-[400] p-6">
         <div class="flex flex-col bg-cat-surface border border-cat-border rounded-xl shadow-2xl overflow-hidden w-[min(720px,100%)] max-h-[min(70vh,620px)]">
           <div class="flex items-center justify-between gap-4 px-4 py-3.5 border-b border-cat-overlay">
             <div>
               <div class="text-sm font-semibold text-cat-text capitalize">${this.operation}</div>
-              <div class="git-overlay-status ${statusClass} ${this.error ? 'error' : ''}">
+              <div data-testid="git-overlay-status" ?data-error=${!!this.error} class="${statusClass}">
                 ${this.error
                   ? this.error
                   : this.status === 'completed'
@@ -35,7 +35,7 @@ export class GitOperationOverlay extends AppElement {
               Schließen
             </button>
           </div>
-          <div class="git-overlay-log p-4 overflow-auto font-mono text-[0.78rem] leading-relaxed text-cat-muted space-y-1.5">
+          <div data-testid="git-overlay-log" class="p-4 overflow-auto font-mono text-[0.78rem] leading-relaxed text-cat-muted space-y-1.5">
             ${this.lines.length > 0
               ? this.lines.map(line => html`<div>${line}</div>`)
               : html`<div class="text-cat-subtle italic">Warte auf Git-Ausgabe…</div>`}

--- a/src/ghGPT.Frontend/src/components/history-view.ts
+++ b/src/ghGPT.Frontend/src/components/history-view.ts
@@ -298,13 +298,14 @@ export class HistoryView extends AppElement {
         ${this.listError
           ? html`<div class="h-full flex items-center justify-center p-4 text-cat-red text-center">${this.listError}</div>`
           : html`
-              <div class="list-scroll flex-1 overflow-auto relative" @scroll=${this.onListScroll}>
+              <div data-testid="commit-list-scroll" class="list-scroll flex-1 overflow-auto relative" @scroll=${this.onListScroll}>
                 <div style="height:${totalHeight}px; position:relative">
                   ${visibleEntries.map((entry, index) => {
                     const absoluteIndex = start + index;
                     return html`
                       <div
-                        class="list-entry absolute left-0 right-0 h-[88px] px-4 py-3 grid gap-3 border-b border-[rgba(49,50,68,0.8)] cursor-pointer box-border
+                        data-testid="commit-entry"
+                        class="absolute left-0 right-0 h-[88px] px-4 py-3 grid gap-3 border-b border-[rgba(49,50,68,0.8)] cursor-pointer box-border
                           ${this.selectedCommitSha === entry.sha ? 'bg-cat-overlay' : 'hover:bg-[#25273a]'}"
                         style="top:${absoluteIndex * HistoryView.ROW_HEIGHT}px; grid-template-columns: 34px 1fr"
                         @click=${() => this.selectCommit(entry.sha)}>
@@ -323,7 +324,7 @@ export class HistoryView extends AppElement {
               </div>
             `}
 
-        <div class="footer-hint px-3.5 py-2 border-t border-cat-border text-[0.72rem] text-[#8f96b3] shrink-0">
+        <div data-testid="footer-hint" class="px-3.5 py-2 border-t border-cat-border text-[0.72rem] text-[#8f96b3] shrink-0">
           ${this.loadingList ? 'Lade weitere Commits…' : this.hasMore ? 'Weitere Commits werden beim Scrollen geladen.' : `${this.entries.length} Commits geladen`}
         </div>
       </section>
@@ -337,7 +338,7 @@ export class HistoryView extends AppElement {
               ? html`<div class="h-full flex items-center justify-center p-4 text-cat-subtle text-center">Commit auswählen</div>`
               : html`
                   <div class="px-4 py-3.5 border-b border-cat-border bg-cat-surface flex flex-col gap-1.5 shrink-0">
-                    <div class="detail-title text-base font-bold text-[#eef1ff] whitespace-pre-wrap">${this.selectedCommit.message}</div>
+                    <div data-testid="commit-detail-title" class="text-base font-bold text-[#eef1ff] whitespace-pre-wrap">${this.selectedCommit.message}</div>
                     <div class="text-[0.78rem] text-cat-subtext">
                       ${this.selectedCommit.authorName} &lt;${this.selectedCommit.authorEmail}&gt; ·
                       ${this.formatDate(this.selectedCommit.authorDate)} · ${this.selectedCommit.shortSha}
@@ -348,7 +349,8 @@ export class HistoryView extends AppElement {
                     <div class="w-[280px] min-w-[280px] border-r border-cat-border overflow-auto bg-[#1a1b26]">
                       ${this.selectedCommit.files.map((file, index) => html`
                         <div
-                          class="file-item px-3.5 py-3 border-b border-[rgba(49,50,68,0.75)] cursor-pointer flex flex-col gap-0.5
+                          data-testid="commit-file-item"
+                          class="px-3.5 py-3 border-b border-[rgba(49,50,68,0.75)] cursor-pointer flex flex-col gap-0.5
                             ${this.selectedFileIndex === index ? 'bg-cat-overlay' : 'hover:bg-[#25273a]'}"
                           @click=${() => { this.selectedFileIndex = index; }}>
                           <div class="text-[0.8rem] text-[#eef1ff] break-words">${file.path}</div>
@@ -357,7 +359,7 @@ export class HistoryView extends AppElement {
                       `)}
                     </div>
 
-                    <div class="diff-panel flex-1 overflow-auto min-w-0 font-mono text-[0.78rem]">
+                    <div data-testid="diff-panel" class="flex-1 overflow-auto min-w-0 font-mono text-[0.78rem]">
                       ${this.selectedFile ? this.renderPatch(this.selectedFile.patch) : html`<div class="h-full flex items-center justify-center p-4 text-cat-subtle">Keine Datei ausgewählt</div>`}
                     </div>
                   </div>

--- a/src/ghGPT.Frontend/src/components/sidebar.ts
+++ b/src/ghGPT.Frontend/src/components/sidebar.ts
@@ -34,20 +34,21 @@ export class AppSidebar extends AppElement {
       <div class="py-2 flex-1 overflow-y-auto">
         <div class="flex items-center justify-between px-4 py-1 text-[0.65rem] uppercase tracking-widest text-cat-subtle">
           <span>Repositories</span>
-          <button class="add-btn bg-transparent border-none text-cat-subtle cursor-pointer text-base px-1 py-0 leading-none hover:text-cat-text"
+          <button data-testid="add-repo-btn" class="bg-transparent border-none text-cat-subtle cursor-pointer text-base px-1 py-0 leading-none hover:text-cat-text"
             title="Repository hinzufügen"
             @click=${() => this.dispatch('add-repo')}>＋</button>
         </div>
 
         ${this.repos.map(repo => html`
-          <div class="repo-item ${repo.id === this.activeRepoId ? 'active' : ''} group flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors
+          <div data-testid="repo-item" ?data-active=${repo.id === this.activeRepoId}
+            class="group flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors
                       ${repo.id === this.activeRepoId
                         ? 'bg-[#45475a] text-[#cba6f7]'
                         : 'text-cat-text hover:bg-cat-overlay'}"
             @click=${() => this.dispatch('activate-repo', repo.id)}>
             <span>📁</span>
-            <span class="repo-name flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${repo.name}</span>
-            <button class="repo-remove-btn hidden group-hover:flex items-center justify-center ml-auto shrink-0 w-4 h-4
+            <span data-testid="repo-name" class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${repo.name}</span>
+            <button data-testid="repo-remove-btn" class="hidden group-hover:flex items-center justify-center ml-auto shrink-0 w-4 h-4
                            border-none bg-transparent text-cat-subtle cursor-pointer text-xs leading-none rounded-[3px] p-0
                            hover:text-cat-red hover:bg-[#45475a]"
               title="Aus Tracking entfernen"
@@ -58,31 +59,31 @@ export class AppSidebar extends AppElement {
         `)}
 
         <div class="flex items-center justify-between px-4 py-1 text-[0.65rem] uppercase tracking-widest text-cat-subtle mt-2">Workspace</div>
-        <div class="nav-item flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
                     ${this.activeView === 'changes' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'changes')}>
           <span>✏️</span> Änderungen
         </div>
-        <div class="nav-item flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
                     ${this.activeView === 'history' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'history')}>
           <span>🕐</span> History
         </div>
 
         <div class="flex items-center justify-between px-4 py-1 text-[0.65rem] uppercase tracking-widest text-cat-subtle mt-2">Repository</div>
-        <div class="nav-item flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
                     ${this.activeView === 'branches' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'branches')}>
           <span>🌿</span> Branches
         </div>
-        <div class="nav-item flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
                     ${this.activeView === 'pull-requests' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'pull-requests')}>
           <span>🔀</span> Pull Requests
         </div>
 
         <div class="flex items-center justify-between px-4 py-1 text-[0.65rem] uppercase tracking-widest text-cat-subtle mt-2">App</div>
-        <div class="nav-item flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
                     ${this.activeView === 'settings' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'settings')}>
           <span>⚙</span> Einstellungen

--- a/src/ghGPT.Frontend/src/components/toolbar.ts
+++ b/src/ghGPT.Frontend/src/components/toolbar.ts
@@ -71,8 +71,8 @@ export class AppToolbar extends AppElement {
   private _renderAheadBehind(branch: BranchInfo) {
     if (!branch.trackingBranch) return null;
     const parts = [];
-    if (branch.aheadBy > 0) parts.push(html`<span class="branch-dropdown-ahead text-cat-green">↑${branch.aheadBy}</span>`);
-    if (branch.behindBy > 0) parts.push(html`<span class="branch-dropdown-behind text-cat-red">↓${branch.behindBy}</span>`);
+    if (branch.aheadBy > 0) parts.push(html`<span data-testid="branch-dropdown-ahead" class="text-cat-green">↑${branch.aheadBy}</span>`);
+    if (branch.behindBy > 0) parts.push(html`<span data-testid="branch-dropdown-behind" class="text-cat-red">↓${branch.behindBy}</span>`);
     return parts.length > 0
       ? html`<span class="inline-flex gap-[0.35rem] shrink-0 text-[0.72rem] text-cat-subtle">${parts}</span>`
       : null;
@@ -104,19 +104,20 @@ export class AppToolbar extends AppElement {
 
     return html`
       <div class="branch-dropdown-wrapper relative">
-        <button class="toolbar-branch ${branchBtnBase}" ?disabled=${!this.activeRepo}
+        <button data-testid="toolbar-branch" class="${branchBtnBase}" ?disabled=${!this.activeRepo}
           @click=${() => this.showBranchDropdown ? this._closeDropdown() : this._openDropdown()}>
-          <span class="branch-icon">🌿</span> ${this.activeRepo?.currentBranch ?? '–'} ▾
+          <span data-testid="branch-icon">🌿</span> ${this.activeRepo?.currentBranch ?? '–'} ▾
         </button>
         ${this.showBranchDropdown ? html`
-          <div class="branch-dropdown absolute top-[calc(100%+4px)] left-0 min-w-[220px] bg-cat-surface border border-cat-border rounded-lg shadow-2xl z-[200] overflow-hidden">
+          <div data-testid="branch-dropdown" class="absolute top-[calc(100%+4px)] left-0 min-w-[220px] bg-cat-surface border border-cat-border rounded-lg shadow-2xl z-[200] overflow-hidden">
             ${this.branches.filter(b => !b.isRemote).length > 0 ? html`
-              <div class="branch-dropdown-section px-3 pt-1 pb-0.5 text-[0.65rem] uppercase tracking-widest text-cat-subtle">Lokale Branches</div>
+              <div data-testid="branch-dropdown-section" class="px-3 pt-1 pb-0.5 text-[0.65rem] uppercase tracking-widest text-cat-subtle">Lokale Branches</div>
               ${this.branches.filter(b => !b.isRemote).map(b => html`
-                <div class="branch-dropdown-item ${b.isHead ? 'active' : ''} flex items-center gap-2 px-3 py-[0.45rem] text-sm cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis
+                <div data-testid="branch-dropdown-item" ?data-active=${b.isHead}
+                  class="flex items-center gap-2 px-3 py-[0.45rem] text-sm cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis
                             ${b.isHead ? 'text-cat-blue bg-[rgba(137,180,250,0.07)]' : 'text-cat-text hover:bg-cat-overlay'}"
                   @click=${() => !b.isHead && this._checkoutBranch(b.name)}>
-                  <span class="check text-xs shrink-0">${b.isHead ? '✓' : ' '}</span>
+                  <span data-testid="branch-check" class="text-xs shrink-0">${b.isHead ? '✓' : ' '}</span>
                   <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${b.name}</span>
                   ${this._renderAheadBehind(b)}
                 </div>
@@ -124,16 +125,16 @@ export class AppToolbar extends AppElement {
             ` : ''}
             ${this.branches.filter(b => b.isRemote).length > 0 ? html`
               <div class="h-px bg-cat-overlay my-1"></div>
-              <div class="branch-dropdown-section px-3 pt-1 pb-0.5 text-[0.65rem] uppercase tracking-widest text-cat-subtle">Remote Branches</div>
+              <div data-testid="branch-dropdown-section" class="px-3 pt-1 pb-0.5 text-[0.65rem] uppercase tracking-widest text-cat-subtle">Remote Branches</div>
               ${this.branches.filter(b => b.isRemote).map(b => html`
-                <div class="branch-dropdown-item flex items-center gap-2 px-3 py-[0.45rem] text-sm text-cat-text cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis hover:bg-cat-overlay"
+                <div data-testid="branch-dropdown-item" class="flex items-center gap-2 px-3 py-[0.45rem] text-sm text-cat-text cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis hover:bg-cat-overlay"
                   @click=${() => this._checkoutBranch(b.name)}>
                   <span class="text-xs shrink-0"> </span>
                   <span>☁ ${b.name}</span>
                 </div>
               `)}
             ` : ''}
-            <div class="branch-dropdown-footer flex items-center gap-1.5 px-3 py-[0.45rem] text-[0.8rem] text-cat-subtle cursor-pointer border-t border-cat-overlay hover:bg-cat-overlay hover:text-cat-text"
+            <div data-testid="branch-dropdown-footer" class="flex items-center gap-1.5 px-3 py-[0.45rem] text-[0.8rem] text-cat-subtle cursor-pointer border-t border-cat-overlay hover:bg-cat-overlay hover:text-cat-text"
               @click=${() => { this._closeDropdown(); this._emit('navigate', 'branches'); }}>
               ⚙ Branch verwalten…
             </div>


### PR DESCRIPTION
## Summary

- `data-testid` Attribute auf alle 7 Frontend-Komponenten hinzugefügt als linter-sichere Test-Selektoren
- State-Klassen (`.active`, `.head`, `.error`) durch boolesche Data-Attribute (`?data-active`, `?data-head`, `?data-error`) ersetzt
- Alle 10 E2E-Spec-Dateien auf `[data-testid="..."]`-Selektoren umgestellt

## Test plan

- [x] Alle 95 E2E-Tests lokal grün (bestätigt vor dem Commit)
- [x] Build erfolgreich (`npm run build`)

Closes #137