### PR TITLE
feat(issues): GitHub Issues View implementieren

### DIFF
--- a/src/ghGPT.Api/Controllers/IssuesController.cs
+++ b/src/ghGPT.Api/Controllers/IssuesController.cs
@@ -1,0 +1,121 @@
+using ghGPT.Core.Issues;
+using ghGPT.Core.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ghGPT.Api.Controllers;
+
+[ApiController]
+[Route("api/repos/{id}/issues")]
+public class IssuesController(
+    IRepositoryService repositoryService,
+    IIssueService issueService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<IssueListItem>>> GetIssues(
+        string id,
+        [FromQuery] string state = "open")
+    {
+        if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
+            return error!;
+
+        try
+        {
+            var issues = await issueService.GetIssuesAsync(ownerRepo.owner, ownerRepo.repo, state);
+            return Ok(issues);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{number:int}")]
+    public async Task<ActionResult<IssueDetail>> GetIssueDetail(string id, int number)
+    {
+        if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
+            return error!;
+
+        try
+        {
+            var detail = await issueService.GetIssueDetailAsync(ownerRepo.owner, ownerRepo.repo, number);
+            return Ok(detail);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<IssueListItem>> CreateIssue(string id, [FromBody] CreateIssueRequest request)
+    {
+        if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
+            return error!;
+
+        try
+        {
+            var issue = await issueService.CreateAsync(
+                ownerRepo.owner, ownerRepo.repo,
+                request.Title, request.Body, request.Labels);
+            return Ok(issue);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{number:int}/comments")]
+    public async Task<IActionResult> AddComment(string id, int number, [FromBody] AddCommentRequest request)
+    {
+        if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
+            return error!;
+
+        try
+        {
+            await issueService.AddCommentAsync(ownerRepo.owner, ownerRepo.repo, number, request.Body);
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    private bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
+    {
+        result = default;
+        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
+        if (repo is null)
+        {
+            error = NotFound(new { error = "Repository nicht gefunden." });
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(repo.RemoteUrl))
+        {
+            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
+            return false;
+        }
+
+        try
+        {
+            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
+            result = (parsed.Owner, parsed.Repo);
+            error = null;
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            error = BadRequest(new { error = ex.Message });
+            return false;
+        }
+    }
+}
+
+public record CreateIssueRequest(
+    string Title,
+    string Body,
+    IEnumerable<string>? Labels = null);
+
+public record AddCommentRequest(string Body);

--- a/src/ghGPT.Core/Issues/IIssueService.cs
+++ b/src/ghGPT.Core/Issues/IIssueService.cs
@@ -1,0 +1,9 @@
+namespace ghGPT.Core.Issues;
+
+public interface IIssueService
+{
+    Task<IReadOnlyList<IssueListItem>> GetIssuesAsync(string owner, string repo, string state = "open");
+    Task<IssueDetail> GetIssueDetailAsync(string owner, string repo, int number);
+    Task<IssueListItem> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null);
+    Task AddCommentAsync(string owner, string repo, int number, string body);
+}

--- a/src/ghGPT.Core/Issues/IssueDetail.cs
+++ b/src/ghGPT.Core/Issues/IssueDetail.cs
@@ -1,0 +1,15 @@
+namespace ghGPT.Core.Issues;
+
+public record IssueDetail
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public string AuthorLogin { get; init; } = string.Empty;
+    public IReadOnlyList<IssueLabel> Labels { get; init; } = [];
+    public IReadOnlyList<string> Assignees { get; init; } = [];
+    public string? Body { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Core/Issues/IssueLabel.cs
+++ b/src/ghGPT.Core/Issues/IssueLabel.cs
@@ -1,0 +1,7 @@
+namespace ghGPT.Core.Issues;
+
+public record IssueLabel
+{
+    public string Name { get; init; } = string.Empty;
+    public string Color { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Core/Issues/IssueListItem.cs
+++ b/src/ghGPT.Core/Issues/IssueListItem.cs
@@ -1,0 +1,13 @@
+namespace ghGPT.Core.Issues;
+
+public record IssueListItem
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public string AuthorLogin { get; init; } = string.Empty;
+    public IReadOnlyList<IssueLabel> Labels { get; init; } = [];
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Frontend/e2e/issues-view.spec.ts
+++ b/src/ghGPT.Frontend/e2e/issues-view.spec.ts
@@ -1,0 +1,243 @@
+import { test, expect } from '@playwright/test';
+import { createTempRepo, removeTempRepo, importRepo, setActiveRepo, deleteRepo, API } from './helpers';
+
+let repoDir = '';
+let repoId = '';
+
+const MOCK_ISSUES_OPEN = [
+  {
+    number: 42,
+    title: 'Fix the login bug',
+    state: 'open',
+    authorLogin: 'alice',
+    labels: [{ name: 'bug', color: 'ee0701' }],
+    createdAt: '2024-01-10T10:00:00Z',
+    updatedAt: '2024-01-11T09:00:00Z',
+    url: 'https://github.com/owner/repo/issues/42',
+  },
+  {
+    number: 7,
+    title: 'Add dark mode support',
+    state: 'open',
+    authorLogin: 'bob',
+    labels: [{ name: 'enhancement', color: '84b6eb' }],
+    createdAt: '2024-01-05T08:00:00Z',
+    updatedAt: '2024-01-06T12:00:00Z',
+    url: 'https://github.com/owner/repo/issues/7',
+  },
+];
+
+const MOCK_ISSUE_DETAIL = {
+  number: 42,
+  title: 'Fix the login bug',
+  state: 'open',
+  authorLogin: 'alice',
+  labels: [{ name: 'bug', color: 'ee0701' }],
+  assignees: ['charlie'],
+  body: 'Steps to reproduce:\n1. Go to login page\n2. Enter wrong credentials',
+  createdAt: '2024-01-10T10:00:00Z',
+  updatedAt: '2024-01-11T09:00:00Z',
+  url: 'https://github.com/owner/repo/issues/42',
+};
+
+const MOCK_ISSUES_CLOSED = [
+  {
+    number: 3,
+    title: 'Old resolved issue',
+    state: 'closed',
+    authorLogin: 'dave',
+    labels: [],
+    createdAt: '2023-12-01T10:00:00Z',
+    updatedAt: '2023-12-15T14:00:00Z',
+    url: 'https://github.com/owner/repo/issues/3',
+  },
+];
+
+const MOCK_CREATED_ISSUE = {
+  number: 99,
+  title: 'New test issue',
+  state: 'open',
+  authorLogin: 'testuser',
+  labels: [],
+  createdAt: '2024-01-15T10:00:00Z',
+  updatedAt: '2024-01-15T10:00:00Z',
+  url: 'https://github.com/owner/repo/issues/99',
+};
+
+test.beforeAll(async () => {
+  repoDir = createTempRepo();
+  const repo = await importRepo(repoDir);
+  repoId = repo.id;
+  await setActiveRepo(repoId);
+});
+
+test.afterAll(async () => {
+  await deleteRepo(repoId);
+  removeTempRepo(repoDir);
+});
+
+async function gotoIssuesView(page: import('@playwright/test').Page) {
+  // Mock API: open issues list
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_OPEN) })
+  );
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+}
+
+test('zeigt Issues-Liste an', async ({ page }) => {
+  await gotoIssuesView(page);
+
+  const items = page.locator('[data-testid="issue-item"]');
+  await expect(items).toHaveCount(2);
+  await expect(items.first()).toContainText('#42');
+  await expect(items.first()).toContainText('Fix the login bug');
+  await expect(items.nth(1)).toContainText('#7');
+  await expect(items.nth(1)).toContainText('Add dark mode support');
+});
+
+test('zeigt Issue-Detail beim Klick an', async ({ page }) => {
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_OPEN) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues/42`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUE_DETAIL) })
+  );
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+
+  await page.locator('[data-testid="issue-item"]').first().click();
+  await page.locator('[data-testid="issue-detail-header"]').waitFor();
+
+  await expect(page.locator('[data-testid="issue-detail-header"]')).toContainText('#42');
+  await expect(page.locator('[data-testid="issue-detail-header"]')).toContainText('Fix the login bug');
+  await expect(page.locator('[data-testid="issue-detail-header"]')).toContainText('alice');
+  await expect(page.locator('[data-testid="issues-detail-panel"]')).toContainText('Steps to reproduce');
+});
+
+test('State-Filter wechselt zwischen open/closed/all', async ({ page }) => {
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_OPEN) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues?state=closed`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_CLOSED) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues?state=all`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([...MOCK_ISSUES_OPEN, ...MOCK_ISSUES_CLOSED]) })
+  );
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+
+  // Open-Filter ist aktiv → 2 Issues
+  await expect(page.locator('[data-testid="issue-item"]')).toHaveCount(2);
+
+  // Auf Closed wechseln → 1 Issue
+  await page.locator('[data-testid="filter-closed"]').click();
+  await expect(page.locator('[data-testid="issue-item"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="issue-item"]').first()).toContainText('Old resolved issue');
+
+  // Auf All wechseln → 3 Issues
+  await page.locator('[data-testid="filter-all"]').click();
+  await expect(page.locator('[data-testid="issue-item"]')).toHaveCount(3);
+
+  // Zurück auf Open → 2 Issues
+  await page.locator('[data-testid="filter-open"]').click();
+  await expect(page.locator('[data-testid="issue-item"]')).toHaveCount(2);
+});
+
+test('Neues Issue erstellen', async ({ page }) => {
+  let createdBody: unknown;
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_OPEN) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues`, async route => {
+    if (route.request().method() === 'POST') {
+      createdBody = route.request().postDataJSON();
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_CREATED_ISSUE) });
+    } else {
+      route.continue();
+    }
+  });
+  await page.route(`${API}/repos/${repoId}/issues/99`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...MOCK_CREATED_ISSUE, body: null, assignees: [] }) })
+  );
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+
+  await page.locator('[data-testid="new-issue-btn"]').click();
+  await page.locator('[data-testid="create-title-input"]').fill('New test issue');
+  await page.locator('[data-testid="create-body-input"]').fill('This is a test issue body.');
+
+  await page.locator('[data-testid="create-issue-btn"]').click();
+  await page.locator('[data-testid="issue-detail-header"]').waitFor();
+
+  expect((createdBody as { title: string }).title).toBe('New test issue');
+  await expect(page.locator('[data-testid="issue-detail-header"]')).toContainText('#99');
+});
+
+test('Kommentar-Formular öffnen und senden', async ({ page }) => {
+  let commentBody: unknown;
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUES_OPEN) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues/42`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ISSUE_DETAIL) })
+  );
+  await page.route(`${API}/repos/${repoId}/issues/42/comments`, async route => {
+    commentBody = route.request().postDataJSON();
+    route.fulfill({ status: 204, body: '' });
+  });
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+
+  await page.locator('[data-testid="issue-item"]').first().click();
+  await page.locator('[data-testid="issue-detail-header"]').waitFor();
+
+  await page.locator('[data-testid="add-comment-btn"]').click();
+  await page.locator('[data-testid="comment-body-input"]').fill('Great issue, I can reproduce it!');
+  await page.locator('[data-testid="submit-comment-btn"]').click();
+
+  // Formular schließt sich nach erfolgreichem Kommentar
+  await expect(page.locator('[data-testid="comment-body-input"]')).not.toBeVisible();
+  expect((commentBody as { body: string }).body).toBe('Great issue, I can reproduce it!');
+});
+
+test('zeigt Fehlermeldung wenn API nicht erreichbar', async ({ page }) => {
+  await page.route(`${API}/repos/${repoId}/issues?state=open`, route =>
+    route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'Kein GitHub-Remote konfiguriert.' }) })
+  );
+
+  await page.goto('/');
+  await page.evaluate((id) => localStorage.setItem('ghgpt:activeRepoId', id), repoId);
+  await page.reload();
+  await page.locator('app-shell').waitFor();
+  await page.locator('[data-testid="nav-item"]').filter({ hasText: 'Issues' }).first().click();
+  await page.locator('[data-testid="issues-list-panel"]').waitFor();
+
+  await expect(page.locator('[data-testid="list-error"]')).toBeVisible();
+});

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -11,10 +11,11 @@ import './changes-view';
 import './history-view';
 import './branches-view';
 import './pull-requests-view';
+import './issues-view';
 import './settings-view';
 import './chat-panel';
 
-type View = 'changes' | 'history' | 'branches' | 'pull-requests' | 'settings';
+type View = 'changes' | 'history' | 'branches' | 'pull-requests' | 'issues' | 'settings';
 
 @customElement('app-shell')
 export class AppShell extends AppElement {
@@ -79,7 +80,7 @@ export class AppShell extends AppElement {
 
   render() {
     const s = this._appState;
-    const isPadded = this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests';
+    const isPadded = this.activeView !== 'changes' && this.activeView !== 'branches' && this.activeView !== 'pull-requests' && this.activeView !== 'issues';
     const contentClass = `flex flex-col flex-1 overflow-hidden text-cat-text${isPadded ? ' p-4 overflow-auto' : ''}`;
     return html`
       <app-sidebar
@@ -160,6 +161,8 @@ export class AppShell extends AppElement {
         return html`<branches-view .repoId=${s.activeRepoId ?? ''} .refreshKey=${this.historyRefreshKey} @branch-changed=${this._onBranchChanged}></branches-view>`;
       case 'pull-requests':
         return html`<pull-requests-view .repoId=${s.activeRepoId ?? ''}></pull-requests-view>`;
+      case 'issues':
+        return html`<issues-view .repoId=${s.activeRepoId ?? ''}></issues-view>`;
       case 'settings':
         return html`<settings-view @account-changed=${this._onAccountChanged}></settings-view>`;
     }

--- a/src/ghGPT.Frontend/src/components/issues-view.ts
+++ b/src/ghGPT.Frontend/src/components/issues-view.ts
@@ -1,0 +1,327 @@
+import { html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { AppElement } from '../app-element';
+import {
+  repositoryService,
+  type IssueListItem,
+  type IssueDetail,
+} from '../services/repository-service';
+
+@customElement('issues-view')
+export class IssuesView extends AppElement {
+  @property() repoId = '';
+
+  @state() private issues: IssueListItem[] = [];
+  @state() private selectedIssue: IssueDetail | null = null;
+  @state() private selectedNumber: number | null = null;
+  @state() private stateFilter: 'open' | 'closed' | 'all' = 'open';
+  @state() private loading = false;
+  @state() private loadingDetail = false;
+  @state() private error: string | null = null;
+  @state() private detailError: string | null = null;
+  @state() private actionBusy = false;
+  @state() private actionError: string | null = null;
+  @state() private showCreateForm = false;
+  @state() private showCommentForm = false;
+  @state() private createTitle = '';
+  @state() private createBody = '';
+  @state() private createLabels = '';
+  @state() private commentBody = '';
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.repoId) this.loadIssues();
+  }
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has('repoId') && this.repoId) {
+      this.issues = [];
+      this.selectedIssue = null;
+      this.selectedNumber = null;
+      this.error = null;
+      this.showCreateForm = false;
+      this.showCommentForm = false;
+      this.loadIssues();
+    }
+  }
+
+  private async loadIssues() {
+    const requestedRepoId = this.repoId;
+    this.loading = true;
+    this.error = null;
+    try {
+      const result = await repositoryService.getIssues(requestedRepoId, this.stateFilter);
+      if (this.repoId !== requestedRepoId) return;
+      this.issues = result;
+    } catch (e: unknown) {
+      if (this.repoId !== requestedRepoId) return;
+      this.error = e instanceof Error ? e.message : 'Fehler beim Laden der Issues.';
+    } finally {
+      if (this.repoId === requestedRepoId) this.loading = false;
+    }
+  }
+
+  private async selectIssue(number: number) {
+    const requestedRepoId = this.repoId;
+    this.selectedNumber = number;
+    this.selectedIssue = null;
+    this.detailError = null;
+    this.actionError = null;
+    this.showCommentForm = false;
+    this.showCreateForm = false;
+    this.loadingDetail = true;
+    try {
+      const result = await repositoryService.getIssueDetail(requestedRepoId, number);
+      if (this.repoId !== requestedRepoId || this.selectedNumber !== number) return;
+      this.selectedIssue = result;
+    } catch (e: unknown) {
+      if (this.repoId !== requestedRepoId || this.selectedNumber !== number) return;
+      this.detailError = e instanceof Error ? e.message : 'Fehler beim Laden des Issue-Details.';
+    } finally {
+      if (this.repoId === requestedRepoId && this.selectedNumber === number) this.loadingDetail = false;
+    }
+  }
+
+  private async setFilter(filter: 'open' | 'closed' | 'all') {
+    if (this.stateFilter === filter) return;
+    this.stateFilter = filter;
+    this.selectedIssue = null;
+    this.selectedNumber = null;
+    await this.loadIssues();
+  }
+
+  private async _doCreate() {
+    if (!this.createTitle) {
+      this.actionError = 'Titel ist ein Pflichtfeld.';
+      return;
+    }
+    this.actionBusy = true;
+    this.actionError = null;
+    try {
+      const labels = this.createLabels
+        ? this.createLabels.split(',').map(l => l.trim()).filter(Boolean)
+        : undefined;
+      const issue = await repositoryService.createIssue(
+        this.repoId, this.createTitle, this.createBody, labels);
+      this.showCreateForm = false;
+      this.createTitle = '';
+      this.createBody = '';
+      this.createLabels = '';
+      await this.loadIssues();
+      await this.selectIssue(issue.number);
+    } catch (e: unknown) {
+      this.actionError = e instanceof Error ? e.message : 'Fehler beim Erstellen.';
+    } finally {
+      this.actionBusy = false;
+    }
+  }
+
+  private async _doAddComment() {
+    if (!this.commentBody || !this.selectedNumber) return;
+    this.actionBusy = true;
+    this.actionError = null;
+    try {
+      await repositoryService.addIssueComment(this.repoId, this.selectedNumber, this.commentBody);
+      this.commentBody = '';
+      this.showCommentForm = false;
+    } catch (e: unknown) {
+      this.actionError = e instanceof Error ? e.message : 'Fehler beim Kommentieren.';
+    } finally {
+      this.actionBusy = false;
+    }
+  }
+
+  private renderStateBadge(state: string) {
+    const s = state.toLowerCase();
+    if (s === 'closed') return html`<span class="inline-flex items-center px-2 py-0.5 rounded-full text-[0.68rem] font-semibold bg-[rgba(243,139,168,0.15)] text-cat-red border border-[rgba(243,139,168,0.3)]">Closed</span>`;
+    return html`<span class="inline-flex items-center px-2 py-0.5 rounded-full text-[0.68rem] font-semibold bg-[rgba(166,227,161,0.15)] text-cat-green border border-[rgba(166,227,161,0.3)]">Open</span>`;
+  }
+
+  private renderLabel(name: string, color: string) {
+    const hex = color.startsWith('#') ? color : `#${color}`;
+    return html`<span
+      class="inline-flex items-center px-2 py-0.5 rounded-full text-[0.68rem] font-semibold border"
+      style="background:${hex}22;color:${hex};border-color:${hex}55">${name}</span>`;
+  }
+
+  render() {
+    return html`
+      <div data-testid="issues-list-panel" class="w-[380px] min-w-[380px] flex flex-col border-r border-cat-border bg-cat-surface overflow-hidden">
+        <div class="px-4 py-[0.85rem] border-b border-cat-border flex flex-col gap-2 shrink-0 bg-cat-surface">
+          <div class="flex items-center justify-between">
+            <span class="text-[0.95rem] font-bold text-[#eef1ff]">Issues</span>
+            <button data-testid="new-issue-btn"
+              class="px-2.5 py-0.5 text-[0.75rem] border border-cat-green rounded bg-transparent text-cat-green cursor-pointer hover:bg-[rgba(166,227,161,0.1)]"
+              @click=${() => { this.showCreateForm = true; this.selectedNumber = null; this.selectedIssue = null; this.actionError = null; }}>
+              + Neu
+            </button>
+          </div>
+          <div class="flex gap-1.5 items-center">
+            <button data-testid="filter-open"
+              class="px-2.5 py-0.5 text-[0.75rem] border border-cat-muted rounded bg-transparent text-cat-subtext cursor-pointer transition-all hover:bg-cat-overlay hover:text-cat-text ${this.stateFilter === 'open' ? 'bg-cat-blue border-cat-blue !text-[#11111b] font-semibold' : ''}"
+              @click=${() => this.setFilter('open')}>Open</button>
+            <button data-testid="filter-closed"
+              class="px-2.5 py-0.5 text-[0.75rem] border border-cat-muted rounded bg-transparent text-cat-subtext cursor-pointer transition-all hover:bg-cat-overlay hover:text-cat-text ${this.stateFilter === 'closed' ? 'bg-cat-blue border-cat-blue !text-[#11111b] font-semibold' : ''}"
+              @click=${() => this.setFilter('closed')}>Closed</button>
+            <button data-testid="filter-all"
+              class="px-2.5 py-0.5 text-[0.75rem] border border-cat-muted rounded bg-transparent text-cat-subtext cursor-pointer transition-all hover:bg-cat-overlay hover:text-cat-text ${this.stateFilter === 'all' ? 'bg-cat-blue border-cat-blue !text-[#11111b] font-semibold' : ''}"
+              @click=${() => this.setFilter('all')}>All</button>
+            <button data-testid="refresh-btn"
+              class="ml-auto px-2.5 py-0.5 text-[0.75rem] border border-cat-muted rounded bg-transparent text-cat-subtext cursor-pointer hover:bg-cat-overlay hover:text-cat-text disabled:opacity-45 disabled:cursor-not-allowed"
+              @click=${() => this.loadIssues()} ?disabled=${this.loading}>
+              ↻ Aktualisieren
+            </button>
+          </div>
+        </div>
+
+        <div class="flex-1 overflow-y-auto">
+          ${this.loading
+            ? html`<div class="p-8 text-center text-cat-subtle text-[0.88rem]">Lade Issues...</div>`
+            : this.error
+            ? html`<div data-testid="list-error" class="p-8 text-center text-cat-red text-[0.88rem]">${this.error}</div>`
+            : this.issues.length === 0
+            ? html`<div class="p-8 text-center text-cat-subtle text-[0.88rem]">Keine Issues gefunden.</div>`
+            : this.issues.map(issue => html`
+              <div data-testid="issue-item"
+                class="px-4 py-[0.85rem] border-b border-[rgba(49,50,68,0.8)] cursor-pointer flex flex-col gap-[0.35rem] hover:bg-[#25273a] ${this.selectedNumber === issue.number ? 'bg-cat-overlay' : ''}"
+                @click=${() => this.selectIssue(issue.number)}>
+                <div class="flex items-start gap-2">
+                  <span class="text-[0.75rem] text-[#8f96b3] whitespace-nowrap shrink-0 mt-[0.1rem]">#${issue.number}</span>
+                  <span class="text-[0.87rem] font-semibold text-[#eef1ff] leading-[1.3] flex-1 min-w-0 overflow-hidden [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]">${issue.title}</span>
+                </div>
+                <div class="flex flex-wrap items-center gap-[0.4rem] text-[0.74rem] text-[#8f96b3]">
+                  ${this.renderStateBadge(issue.state)}
+                  <span>${issue.authorLogin}</span>
+                  ${issue.labels.map(l => this.renderLabel(l.name, l.color))}
+                </div>
+              </div>
+            `)}
+        </div>
+      </div>
+
+      <div data-testid="issues-detail-panel" class="flex-1 flex flex-col overflow-hidden min-w-0">
+        ${this.showCreateForm ? html`
+          <div class="flex-1 overflow-y-auto p-5 flex flex-col gap-[0.85rem]">
+            <div class="text-[0.95rem] font-bold text-[#eef1ff] mb-1">Neues Issue</div>
+
+            <div>
+              <label class="block text-[0.78rem] text-cat-subtext mb-1">Titel *</label>
+              <input data-testid="create-title-input"
+                class="bg-cat-surface border border-cat-muted rounded-md text-cat-text text-[0.875rem] px-3 py-2 font-[inherit] w-full box-border focus:outline-none focus:border-cat-blue"
+                type="text" .value=${this.createTitle}
+                @input=${(e: Event) => this.createTitle = (e.target as HTMLInputElement).value}
+                placeholder="Issue-Titel" />
+            </div>
+
+            <div>
+              <label class="block text-[0.78rem] text-cat-subtext mb-1">Beschreibung</label>
+              <textarea data-testid="create-body-input"
+                class="bg-cat-surface border border-cat-muted rounded-md text-cat-text text-[0.875rem] px-3 py-2 font-[inherit] w-full box-border min-h-[120px] resize-y leading-[1.5] focus:outline-none focus:border-cat-blue"
+                .value=${this.createBody}
+                @input=${(e: Event) => this.createBody = (e.target as HTMLTextAreaElement).value}
+                placeholder="Beschreibung des Issues..."></textarea>
+            </div>
+
+            <div>
+              <label class="block text-[0.78rem] text-cat-subtext mb-1">Labels (kommasepariert)</label>
+              <input data-testid="create-labels-input"
+                class="bg-cat-surface border border-cat-muted rounded-md text-cat-text text-[0.875rem] px-3 py-2 font-[inherit] w-full box-border focus:outline-none focus:border-cat-blue"
+                type="text" .value=${this.createLabels}
+                @input=${(e: Event) => this.createLabels = (e.target as HTMLInputElement).value}
+                placeholder="bug, enhancement" />
+            </div>
+
+            ${this.actionError ? html`<div data-testid="create-error" class="text-cat-red text-[0.8rem] px-4 py-2 bg-[rgba(243,139,168,0.08)] rounded">${this.actionError}</div>` : ''}
+
+            <div class="flex gap-2 justify-end mt-1">
+              <button class="px-3 py-1 text-[0.78rem] border border-cat-border rounded-md bg-transparent text-cat-text cursor-pointer whitespace-nowrap hover:bg-cat-overlay"
+                @click=${() => { this.showCreateForm = false; this.actionError = null; }}>
+                Abbrechen
+              </button>
+              <button data-testid="create-issue-btn"
+                class="px-3 py-1 text-[0.78rem] border border-cat-blue rounded-md bg-transparent text-cat-blue cursor-pointer whitespace-nowrap hover:bg-[rgba(137,180,250,0.1)] disabled:opacity-45 disabled:cursor-not-allowed"
+                ?disabled=${this.actionBusy} @click=${this._doCreate}>
+                ${this.actionBusy ? 'Erstelle...' : 'Issue erstellen'}
+              </button>
+            </div>
+          </div>
+        ` : this.selectedNumber === null
+          ? html`
+            <div class="flex-1 flex flex-col items-center justify-center gap-3 text-cat-subtle text-[0.9rem]">
+              <span class="text-[2.5rem]">🐛</span>
+              <span>Issue auswählen</span>
+            </div>
+          `
+          : this.loadingDetail
+          ? html`<div class="p-8 text-center text-cat-subtle text-[0.88rem]">Lade Details...</div>`
+          : this.detailError
+          ? html`<div data-testid="detail-error" class="p-8 text-center text-cat-red text-[0.88rem]">${this.detailError}</div>`
+          : this.selectedIssue
+          ? html`
+            <div data-testid="issue-detail-header" class="px-4 py-[0.9rem] border-b border-cat-border bg-cat-surface shrink-0">
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="text-[1rem] font-bold text-[#eef1ff] leading-[1.4] flex-1">#${this.selectedIssue.number} ${this.selectedIssue.title}</div>
+                <div class="flex gap-1.5 shrink-0 items-center">
+                  <button data-testid="add-comment-btn"
+                    class="px-3 py-1 text-[0.78rem] border border-cat-border rounded-md bg-transparent text-cat-text cursor-pointer whitespace-nowrap hover:bg-cat-overlay"
+                    @click=${() => { this.showCommentForm = !this.showCommentForm; this.actionError = null; }}>
+                    💬 Kommentar
+                  </button>
+                  <button
+                    class="px-3 py-1 text-[0.78rem] border border-cat-border rounded-md bg-transparent text-cat-blue cursor-pointer whitespace-nowrap shrink-0 hover:bg-[rgba(137,180,250,0.1)] hover:border-cat-blue"
+                    @click=${() => window.open(this.selectedIssue!.url, '_blank')}>
+                    Auf GitHub ↗
+                  </button>
+                </div>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-[0.78rem] text-cat-subtext">
+                ${this.renderStateBadge(this.selectedIssue.state)}
+                <span>${this.selectedIssue.authorLogin}</span>
+                ${this.selectedIssue.assignees.length > 0 ? html`
+                  <span class="text-cat-subtle">→</span>
+                  ${this.selectedIssue.assignees.map(a => html`<span class="text-cat-subtext">${a}</span>`)}
+                ` : ''}
+                ${this.selectedIssue.labels.map(l => this.renderLabel(l.name, l.color))}
+              </div>
+              ${this.actionError ? html`<div class="text-cat-red text-[0.8rem] px-4 py-2 bg-[rgba(243,139,168,0.08)] rounded mt-2">${this.actionError}</div>` : ''}
+            </div>
+
+            ${this.showCommentForm ? html`
+              <div class="px-4 py-4 flex flex-col gap-3 border-b border-cat-border bg-cat-base">
+                <div class="text-[0.8rem] font-bold text-cat-subtext uppercase tracking-[0.07em]">Kommentar hinzufügen</div>
+                <textarea data-testid="comment-body-input"
+                  class="bg-cat-surface border border-cat-muted rounded-md text-cat-text text-[0.875rem] px-3 py-2 font-[inherit] w-full box-border min-h-[80px] resize-y leading-[1.5] focus:outline-none focus:border-cat-blue"
+                  .value=${this.commentBody}
+                  @input=${(e: Event) => this.commentBody = (e.target as HTMLTextAreaElement).value}
+                  placeholder="Kommentar..."></textarea>
+                <div class="flex gap-2 justify-end">
+                  <button class="px-3 py-1 text-[0.78rem] border border-cat-border rounded-md bg-transparent text-cat-text cursor-pointer whitespace-nowrap hover:bg-cat-overlay"
+                    @click=${() => { this.showCommentForm = false; this.commentBody = ''; this.actionError = null; }}>
+                    Abbrechen
+                  </button>
+                  <button data-testid="submit-comment-btn"
+                    class="px-3 py-1 text-[0.78rem] border border-cat-blue rounded-md bg-transparent text-cat-blue cursor-pointer whitespace-nowrap hover:bg-[rgba(137,180,250,0.1)] disabled:opacity-45 disabled:cursor-not-allowed"
+                    ?disabled=${this.actionBusy || !this.commentBody} @click=${this._doAddComment}>
+                    ${this.actionBusy ? 'Sende...' : 'Kommentieren'}
+                  </button>
+                </div>
+              </div>
+            ` : ''}
+
+            <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-5">
+              ${this.selectedIssue.body ? html`
+                <div>
+                  <div class="text-[0.8rem] font-bold text-cat-subtext uppercase tracking-[0.07em] mb-2">Beschreibung</div>
+                  <pre class="text-[0.85rem] text-cat-text leading-[1.6] whitespace-pre-wrap font-[inherit] bg-cat-base px-3 py-3 rounded-md border border-cat-border m-0">${this.selectedIssue.body}</pre>
+                </div>
+              ` : html`
+                <div class="text-cat-subtle text-[0.88rem] italic">Keine Beschreibung vorhanden.</div>
+              `}
+            </div>
+          `
+          : ''
+        }
+      </div>
+    `;
+  }
+}

--- a/src/ghGPT.Frontend/src/components/sidebar.ts
+++ b/src/ghGPT.Frontend/src/components/sidebar.ts
@@ -4,7 +4,7 @@ import { AppElement } from '../app-element';
 import type { RepositoryInfo, AccountInfo } from '../services/repository-service';
 import type { HubConnectionStatus } from '../services/hub-client';
 
-type View = 'changes' | 'history' | 'branches' | 'pull-requests' | 'settings';
+type View = 'changes' | 'history' | 'branches' | 'pull-requests' | 'issues' | 'settings';
 
 @customElement('app-sidebar')
 export class AppSidebar extends AppElement {
@@ -80,6 +80,11 @@ export class AppSidebar extends AppElement {
                     ${this.activeView === 'pull-requests' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
           @click=${() => this.dispatch('navigate', 'pull-requests')}>
           <span>🔀</span> Pull Requests
+        </div>
+        <div data-testid="nav-item" class="flex items-center gap-2 px-4 py-[0.4rem] cursor-pointer text-sm transition-colors whitespace-nowrap overflow-hidden text-ellipsis
+                    ${this.activeView === 'issues' ? 'bg-[#45475a] text-[#cba6f7]' : 'text-cat-text hover:bg-cat-overlay'}"
+          @click=${() => this.dispatch('navigate', 'issues')}>
+          <span>🐛</span> Issues
         </div>
 
         <div class="flex items-center justify-between px-4 py-1 text-[0.65rem] uppercase tracking-widest text-cat-subtle mt-2">App</div>

--- a/src/ghGPT.Frontend/src/services/repository-service.ts
+++ b/src/ghGPT.Frontend/src/services/repository-service.ts
@@ -138,6 +138,35 @@ export interface PullRequestDetail {
   updatedAt: string;
 }
 
+export interface IssueLabel {
+  name: string;
+  color: string;
+}
+
+export interface IssueListItem {
+  number: number;
+  title: string;
+  state: string;
+  authorLogin: string;
+  labels: IssueLabel[];
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+}
+
+export interface IssueDetail {
+  number: number;
+  title: string;
+  state: string;
+  authorLogin: string;
+  labels: IssueLabel[];
+  assignees: string[];
+  body: string | null;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+}
+
 export interface StageLinesRequest {
   filePath: string;
   patch: string;
@@ -212,6 +241,15 @@ export const repositoryService = {
     api.patch<void>(`/repos/${id}/pull-requests/${number}/reopen`, {}),
   mergePullRequest: (id: string, number: number, method: 'merge' | 'squash' | 'rebase' = 'merge', commitTitle?: string, commitBody?: string) =>
     api.post<void>(`/repos/${id}/pull-requests/${number}/merge`, { method, commitTitle, commitBody }),
+
+  getIssues: (id: string, state: 'open' | 'closed' | 'all' = 'open') =>
+    api.get<IssueListItem[]>(`/repos/${id}/issues?state=${state}`),
+  getIssueDetail: (id: string, number: number) =>
+    api.get<IssueDetail>(`/repos/${id}/issues/${number}`),
+  createIssue: (id: string, title: string, body: string, labels?: string[]) =>
+    api.post<IssueListItem>(`/repos/${id}/issues`, { title, body, labels }),
+  addIssueComment: (id: string, number: number, body: string) =>
+    api.post<void>(`/repos/${id}/issues/${number}/comments`, { body }),
 
   saveActiveId: (id: string) => localStorage.setItem(ACTIVE_REPO_KEY, id),
   loadActiveId: () => localStorage.getItem(ACTIVE_REPO_KEY),

--- a/src/ghGPT.Frontend/src/styles/app.css
+++ b/src/ghGPT.Frontend/src/styles/app.css
@@ -85,7 +85,8 @@ branches-view {
   overflow: hidden;
 }
 
-pull-requests-view {
+pull-requests-view,
+issues-view {
   display: flex;
   height: 100%;
   overflow: hidden;

--- a/src/ghGPT.Infrastructure/DependencyInjection.cs
+++ b/src/ghGPT.Infrastructure/DependencyInjection.cs
@@ -11,6 +11,7 @@ public static class DependencyInjection
         services.AddAiServices();
         services.AddRepositoryServices();
         services.AddPullRequestServices();
+        services.AddIssueServices();
         return services;
     }
 }

--- a/src/ghGPT.Infrastructure/Issues/IssueService.cs
+++ b/src/ghGPT.Infrastructure/Issues/IssueService.cs
@@ -1,0 +1,60 @@
+using GhCli.Net.Abstractions;
+using ghGPT.Core.Issues;
+
+namespace ghGPT.Infrastructure.Issues;
+
+public class IssueService(IIssueClient issueClient) : IIssueService
+{
+    public async Task<IReadOnlyList<IssueListItem>> GetIssuesAsync(string owner, string repo, string state = "open")
+    {
+        var issues = await issueClient.ListAsync(owner, repo, state);
+        return issues.Select(i => new IssueListItem
+        {
+            Number = i.Number,
+            Title = i.Title,
+            State = i.State,
+            AuthorLogin = i.Author.Login,
+            Labels = i.Labels.Select(l => new IssueLabel { Name = l.Name, Color = l.Color }).ToList(),
+            CreatedAt = i.CreatedAt,
+            UpdatedAt = i.UpdatedAt,
+            Url = i.Url
+        }).ToList();
+    }
+
+    public async Task<IssueDetail> GetIssueDetailAsync(string owner, string repo, int number)
+    {
+        var i = await issueClient.GetDetailAsync(owner, repo, number);
+        return new IssueDetail
+        {
+            Number = i.Number,
+            Title = i.Title,
+            State = i.State,
+            AuthorLogin = i.Author.Login,
+            Labels = i.Labels.Select(l => new IssueLabel { Name = l.Name, Color = l.Color }).ToList(),
+            Assignees = i.Assignees.Select(a => a.Login).ToList(),
+            Body = i.Body,
+            CreatedAt = i.CreatedAt,
+            UpdatedAt = i.UpdatedAt,
+            Url = i.Url
+        };
+    }
+
+    public async Task<IssueListItem> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null)
+    {
+        var i = await issueClient.CreateAsync(owner, repo, title, body, labels);
+        return new IssueListItem
+        {
+            Number = i.Number,
+            Title = i.Title,
+            State = i.State,
+            AuthorLogin = i.Author.Login,
+            Labels = i.Labels.Select(l => new IssueLabel { Name = l.Name, Color = l.Color }).ToList(),
+            CreatedAt = i.CreatedAt,
+            UpdatedAt = i.UpdatedAt,
+            Url = i.Url
+        };
+    }
+
+    public Task AddCommentAsync(string owner, string repo, int number, string body) =>
+        issueClient.AddCommentAsync(owner, repo, number, body);
+}

--- a/src/ghGPT.Infrastructure/Issues/IssueServiceExtensions.cs
+++ b/src/ghGPT.Infrastructure/Issues/IssueServiceExtensions.cs
@@ -1,0 +1,14 @@
+using ghGPT.Core.Issues;
+using ghGPT.Infrastructure.Issues;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ghGPT.Infrastructure;
+
+internal static class IssueServiceExtensions
+{
+    internal static IServiceCollection AddIssueServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IIssueService, IssueService>();
+        return services;
+    }
+}


### PR DESCRIPTION
Closes #140

## Summary
- **Core**: `IssueListItem`, `IssueDetail`, `IssueLabel`, `IIssueService`
- **Infrastructure**: `IssueService` (wraps `IIssueClient` aus GhCli.Net) + DI-Registrierung
- **API**: `IssuesController` — `GET /api/repos/{id}/issues`, `GET /api/repos/{id}/issues/{number}`, `POST /api/repos/{id}/issues`, `POST /api/repos/{id}/issues/{number}/comments`
- **Frontend**: `issues-view` Lit-Komponente mit zweispaltigem Layout (Liste links, Detail rechts), State-Filter (open/closed/all), Neu-Issue-Dialog, Kommentar-Formular; Sidebar-Nav-Eintrag; app-shell Routing; CSS-Fix (`display: flex`)
- **E2E**: `issues-view.spec.ts` mit 5 Tests via Playwright API-Mocking

## Test plan
- [x] Issues-Liste lädt für ein Repository mit GitHub-Remote
- [x] State-Filter (Open / Closed / All) wechselt korrekt
- [x] Klick auf Issue zeigt Detail-Panel mit Body, Labels, Assignees
- [x] "Auf GitHub ↗" öffnet die Issue-URL
- [x] Neues Issue erstellen via "+ Neu"-Dialog
- [x] Kommentar hinzufügen via "💬 Kommentar"-Button
- [x] Fehlermeldung bei fehlendem GitHub-Remote