### PR TITLE
fix(releases): Fehlende Core- und Infrastructure-Schicht nachholen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ mono_crash.*
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
-[Rr]eleases/
+bin/[Rr]eleases/
 x64/
 x86/
 [Ww][Ii][Nn]32/

--- a/src/GhCli.Net/Releases/Models/Release.cs
+++ b/src/GhCli.Net/Releases/Models/Release.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Releases.Models;
+
+public record Release
+{
+    [JsonPropertyName("tagName")] public string TagName { get; init; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+    [JsonPropertyName("isDraft")] public bool IsDraft { get; init; }
+    [JsonPropertyName("isPrerelease")] public bool IsPrerelease { get; init; }
+    [JsonPropertyName("isLatest")] public bool IsLatest { get; init; }
+    [JsonPropertyName("publishedAt")] public DateTimeOffset PublishedAt { get; init; }
+    [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Releases/Models/ReleaseAuthor.cs
+++ b/src/GhCli.Net/Releases/Models/ReleaseAuthor.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Releases.Models;
+
+public record ReleaseAuthor
+{
+    [JsonPropertyName("login")] public string Login { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Releases/Models/ReleaseDetail.cs
+++ b/src/GhCli.Net/Releases/Models/ReleaseDetail.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Releases.Models;
+
+public record ReleaseDetail
+{
+    [JsonPropertyName("tagName")] public string TagName { get; init; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+    [JsonPropertyName("isDraft")] public bool IsDraft { get; init; }
+    [JsonPropertyName("isPrerelease")] public bool IsPrerelease { get; init; }
+    [JsonPropertyName("body")] public string? Body { get; init; }
+    [JsonPropertyName("publishedAt")] public DateTimeOffset PublishedAt { get; init; }
+    [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
+    [JsonPropertyName("author")] public ReleaseAuthor Author { get; init; } = new();
+}

--- a/src/GhCli.Net/Releases/ReleaseClient.cs
+++ b/src/GhCli.Net/Releases/ReleaseClient.cs
@@ -1,0 +1,57 @@
+using GhCli.Net.Abstractions;
+using GhCli.Net.Releases.Models;
+using System.Text.Json;
+
+namespace GhCli.Net.Releases;
+
+internal class ReleaseClient(IGhCliRunner runner) : IReleaseClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    private const string ListFields = "tagName,name,isDraft,isPrerelease,isLatest,publishedAt";
+    private const string DetailFields = "tagName,name,isDraft,isPrerelease,body,publishedAt,url,author";
+
+    public async Task<IReadOnlyList<Release>> ListAsync(string owner, string repo, int limit = 30)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var json = await runner.RunAsync(
+            "release", "list",
+            "--repo", $"{owner}/{repo}",
+            "--limit", limit.ToString(),
+            "--json", ListFields);
+
+        return JsonSerializer.Deserialize<List<Release>>(json, JsonOptions) ?? [];
+    }
+
+    public async Task<ReleaseDetail> GetLatestAsync(string owner, string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var json = await runner.RunAsync(
+            "release", "view",
+            "--repo", $"{owner}/{repo}",
+            "--json", DetailFields);
+
+        return JsonSerializer.Deserialize<ReleaseDetail>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Neuestes Release konnte nicht abgerufen werden.");
+    }
+
+    public async Task<ReleaseDetail> GetByTagAsync(string owner, string repo, string tag)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag);
+
+        var json = await runner.RunAsync(
+            "release", "view", tag,
+            "--repo", $"{owner}/{repo}",
+            "--json", DetailFields);
+
+        return JsonSerializer.Deserialize<ReleaseDetail>(json, JsonOptions)
+            ?? throw new InvalidOperationException($"Release '{tag}' konnte nicht abgerufen werden.");
+    }
+}

--- a/src/ghGPT.Core/Releases/IReleaseService.cs
+++ b/src/ghGPT.Core/Releases/IReleaseService.cs
@@ -1,0 +1,8 @@
+namespace ghGPT.Core.Releases;
+
+public interface IReleaseService
+{
+    Task<IReadOnlyList<ReleaseListItem>> GetReleasesAsync(string owner, string repo, int limit = 30);
+    Task<ReleaseDetail> GetLatestAsync(string owner, string repo);
+    Task<ReleaseDetail> GetByTagAsync(string owner, string repo, string tag);
+}

--- a/src/ghGPT.Core/Releases/ReleaseDetail.cs
+++ b/src/ghGPT.Core/Releases/ReleaseDetail.cs
@@ -1,0 +1,13 @@
+namespace ghGPT.Core.Releases;
+
+public record ReleaseDetail
+{
+    public string TagName { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public bool IsDraft { get; init; }
+    public bool IsPrerelease { get; init; }
+    public string? Body { get; init; }
+    public DateTimeOffset PublishedAt { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string AuthorLogin { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Core/Releases/ReleaseListItem.cs
+++ b/src/ghGPT.Core/Releases/ReleaseListItem.cs
@@ -1,0 +1,12 @@
+namespace ghGPT.Core.Releases;
+
+public record ReleaseListItem
+{
+    public string TagName { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public bool IsDraft { get; init; }
+    public bool IsPrerelease { get; init; }
+    public bool IsLatest { get; init; }
+    public DateTimeOffset PublishedAt { get; init; }
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/ghGPT.Infrastructure/Releases/ReleaseService.cs
+++ b/src/ghGPT.Infrastructure/Releases/ReleaseService.cs
@@ -1,0 +1,46 @@
+using GhCli.Net.Abstractions;
+using ghGPT.Core.Releases;
+
+namespace ghGPT.Infrastructure.Releases;
+
+public class ReleaseService(IReleaseClient releaseClient) : IReleaseService
+{
+    public async Task<IReadOnlyList<ReleaseListItem>> GetReleasesAsync(string owner, string repo, int limit = 30)
+    {
+        var releases = await releaseClient.ListAsync(owner, repo, limit);
+        return releases.Select(r => new ReleaseListItem
+        {
+            TagName = r.TagName,
+            Name = r.Name,
+            IsDraft = r.IsDraft,
+            IsPrerelease = r.IsPrerelease,
+            IsLatest = r.IsLatest,
+            PublishedAt = r.PublishedAt,
+            Url = $"https://github.com/{owner}/{repo}/releases/tag/{r.TagName}"
+        }).ToList();
+    }
+
+    public async Task<ReleaseDetail> GetLatestAsync(string owner, string repo)
+    {
+        var r = await releaseClient.GetLatestAsync(owner, repo);
+        return Map(r);
+    }
+
+    public async Task<ReleaseDetail> GetByTagAsync(string owner, string repo, string tag)
+    {
+        var r = await releaseClient.GetByTagAsync(owner, repo, tag);
+        return Map(r);
+    }
+
+    private static ReleaseDetail Map(GhCli.Net.Releases.Models.ReleaseDetail r) => new()
+    {
+        TagName = r.TagName,
+        Name = r.Name,
+        IsDraft = r.IsDraft,
+        IsPrerelease = r.IsPrerelease,
+        Body = r.Body,
+        PublishedAt = r.PublishedAt,
+        Url = r.Url,
+        AuthorLogin = r.Author.Login
+    };
+}

--- a/src/ghGPT.Infrastructure/Releases/ReleaseServiceExtensions.cs
+++ b/src/ghGPT.Infrastructure/Releases/ReleaseServiceExtensions.cs
@@ -1,0 +1,14 @@
+using ghGPT.Core.Releases;
+using ghGPT.Infrastructure.Releases;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ghGPT.Infrastructure;
+
+internal static class ReleaseServiceExtensions
+{
+    internal static IServiceCollection AddReleaseServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IReleaseService, ReleaseService>();
+        return services;
+    }
+}

--- a/tests/GhCli.Net.Tests/ReleaseClientTests.cs
+++ b/tests/GhCli.Net.Tests/ReleaseClientTests.cs
@@ -30,6 +30,7 @@ public class ReleaseClientTests
                 isDraft = false,
                 isPrerelease = false,
                 isLatest = true
+                // url is not available from gh release list
             }
         });
         _runner.RunAsync("release", "list", "--repo", "slekrem/ghGPT", "--limit", "30", "--json", Arg.Any<string>())

--- a/tests/ghGPT.Infrastructure.Tests/ReleaseServiceTests.cs
+++ b/tests/ghGPT.Infrastructure.Tests/ReleaseServiceTests.cs
@@ -1,0 +1,165 @@
+using GhCli.Net.Abstractions;
+using GhCli.Net.Releases.Models;
+using ghGPT.Infrastructure.Releases;
+using NSubstitute;
+
+namespace ghGPT.Infrastructure.Tests;
+
+public class ReleaseServiceTests
+{
+    private readonly IReleaseClient _client = Substitute.For<IReleaseClient>();
+    private readonly ReleaseService _sut;
+
+    public ReleaseServiceTests()
+    {
+        _sut = new ReleaseService(_client);
+    }
+
+    // --- GetReleasesAsync ---
+
+    [Fact]
+    public async Task GetReleasesAsync_MapsAllFields()
+    {
+        _client.ListAsync("owner", "repo", 30).Returns([
+            new Release
+            {
+                TagName = "v1.0.0",
+                Name = "Version 1.0.0",
+                IsDraft = false,
+                IsPrerelease = false,
+                IsLatest = true,
+                PublishedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                Url = "https://github.com/owner/repo/releases/tag/v1.0.0"
+            }
+        ]);
+
+        var result = await _sut.GetReleasesAsync("owner", "repo");
+
+        Assert.Single(result);
+        var item = result[0];
+        Assert.Equal("v1.0.0", item.TagName);
+        Assert.Equal("Version 1.0.0", item.Name);
+        Assert.False(item.IsDraft);
+        Assert.False(item.IsPrerelease);
+        Assert.True(item.IsLatest);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), item.PublishedAt);
+        Assert.Equal("https://github.com/owner/repo/releases/tag/v1.0.0", item.Url); // constructed, not from API
+    }
+
+    [Fact]
+    public async Task GetReleasesAsync_ReturnsEmptyList_WhenNoReleases()
+    {
+        _client.ListAsync("owner", "repo", 30).Returns([]);
+
+        var result = await _sut.GetReleasesAsync("owner", "repo");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetReleasesAsync_ReturnsMultipleReleases()
+    {
+        _client.ListAsync("owner", "repo", 30).Returns([
+            new Release { TagName = "v2.0.0", IsLatest = true },
+            new Release { TagName = "v1.0.0", IsLatest = false }
+        ]);
+
+        var result = await _sut.GetReleasesAsync("owner", "repo");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("v2.0.0", result[0].TagName);
+        Assert.Equal("v1.0.0", result[1].TagName);
+    }
+
+    [Fact]
+    public async Task GetReleasesAsync_PassesLimitToClient()
+    {
+        _client.ListAsync("owner", "repo", 10).Returns([]);
+
+        await _sut.GetReleasesAsync("owner", "repo", limit: 10);
+
+        await _client.Received(1).ListAsync("owner", "repo", 10);
+    }
+
+    // --- GetLatestAsync ---
+
+    [Fact]
+    public async Task GetLatestAsync_MapsAllFields()
+    {
+        _client.GetLatestAsync("owner", "repo").Returns(new ReleaseDetail
+        {
+            TagName = "v1.0.0",
+            Name = "Version 1.0.0",
+            IsDraft = false,
+            IsPrerelease = false,
+            Body = "## Changelog\n- Feature A",
+            PublishedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            Url = "https://github.com/owner/repo/releases/tag/v1.0.0",
+            Author = new ReleaseAuthor { Login = "slekrem" }
+        });
+
+        var result = await _sut.GetLatestAsync("owner", "repo");
+
+        Assert.Equal("v1.0.0", result.TagName);
+        Assert.Equal("Version 1.0.0", result.Name);
+        Assert.False(result.IsDraft);
+        Assert.False(result.IsPrerelease);
+        Assert.Equal("## Changelog\n- Feature A", result.Body);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), result.PublishedAt);
+        Assert.Equal("https://github.com/owner/repo/releases/tag/v1.0.0", result.Url);
+        Assert.Equal("slekrem", result.AuthorLogin);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_MapsNullBody()
+    {
+        _client.GetLatestAsync("owner", "repo").Returns(new ReleaseDetail
+        {
+            TagName = "v1.0.0",
+            Body = null,
+            Author = new ReleaseAuthor { Login = "slekrem" }
+        });
+
+        var result = await _sut.GetLatestAsync("owner", "repo");
+
+        Assert.Null(result.Body);
+    }
+
+    // --- GetByTagAsync ---
+
+    [Fact]
+    public async Task GetByTagAsync_MapsAllFields()
+    {
+        _client.GetByTagAsync("owner", "repo", "v1.0.0-rc.1").Returns(new ReleaseDetail
+        {
+            TagName = "v1.0.0-rc.1",
+            Name = "Release Candidate 1",
+            IsDraft = false,
+            IsPrerelease = true,
+            Body = null,
+            PublishedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            Url = "https://github.com/owner/repo/releases/tag/v1.0.0-rc.1",
+            Author = new ReleaseAuthor { Login = "slekrem" }
+        });
+
+        var result = await _sut.GetByTagAsync("owner", "repo", "v1.0.0-rc.1");
+
+        Assert.Equal("v1.0.0-rc.1", result.TagName);
+        Assert.True(result.IsPrerelease);
+        Assert.False(result.IsDraft);
+        Assert.Equal("slekrem", result.AuthorLogin);
+    }
+
+    [Fact]
+    public async Task GetByTagAsync_PassesTagToClient()
+    {
+        _client.GetByTagAsync("owner", "repo", "v2.0.0").Returns(new ReleaseDetail
+        {
+            Author = new ReleaseAuthor { Login = "slekrem" }
+        });
+
+        await _sut.GetByTagAsync("owner", "repo", "v2.0.0");
+
+        await _client.Received(1).GetByTagAsync("owner", "repo", "v2.0.0");
+    }
+}


### PR DESCRIPTION
## Summary

- `ghGPT.Core/Releases/` fehlte komplett — `IReleaseService`, `ReleaseListItem`, `ReleaseDetail` hinzugefügt
- `ghGPT.Infrastructure/Releases/` fehlte komplett — `ReleaseService` (mit URL-Konstruktion aus `owner/repo/tagName`) und `ReleaseServiceExtensions` hinzugefügt
- `.gitignore`-Eintrag `[Rr]eleases/` auf `bin/[Rr]eleases/` korrigiert, der fälschlicherweise alle Source-Ordner mit dem Namen `Releases` ignoriert hatte
- Unit-Tests für alle drei `ReleaseService`-Methoden in `ghGPT.Infrastructure.Tests`

## Root Cause

PR #145 hat `ReleasesController`, Frontend und DI-Registrierung (`AddReleaseServices()`) commitet, aber die eigentliche Core/Infrastructure-Implementierung vergessen. Da `.gitignore` alle `Releases/`-Ordner ignorierte, wurden die nachträglich erstellten Dateien nie getrackt — der Build war broken.

Closes #151