### PR TITLE
feat(GhCli.Net): LinkedBranches – verknüpfte Issues eines Branches abfragen

### DIFF
--- a/src/GhCli.Net/Abstractions/IIssueClient.cs
+++ b/src/GhCli.Net/Abstractions/IIssueClient.cs
@@ -6,6 +6,7 @@ public interface IIssueClient
 {
     Task<IReadOnlyList<Issue>> ListAsync(string owner, string repo, string state = "open", int limit = 30);
     Task<IssueDetail> GetDetailAsync(string owner, string repo, int number);
+    Task<IssueDetail?> GetLinkedIssueForBranchAsync(string owner, string repo, string branchName);
     Task<Issue> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null);
     Task AddCommentAsync(string owner, string repo, int number, string body);
 }

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchAssigneeConnection.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchAssigneeConnection.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchAssigneeConnection
+{
+    [JsonPropertyName("nodes")]
+    public IReadOnlyList<LinkedBranchAssigneeNode> Nodes { get; init; } = [];
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchAssigneeNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchAssigneeNode.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchAssigneeNode
+{
+    [JsonPropertyName("login")]
+    public string Login { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchAuthorNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchAuthorNode.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchAuthorNode
+{
+    [JsonPropertyName("login")]
+    public string Login { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchConnection.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchConnection.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchConnection
+{
+    [JsonPropertyName("nodes")]
+    public IReadOnlyList<LinkedBranchNode> Nodes { get; init; } = [];
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchIssueNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchIssueNode.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchIssueNode
+{
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("state")]
+    public string State { get; init; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+
+    [JsonPropertyName("body")]
+    public string? Body { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    [JsonPropertyName("author")]
+    public LinkedBranchAuthorNode? Author { get; init; }
+
+    [JsonPropertyName("labels")]
+    public LinkedBranchLabelConnection? Labels { get; init; }
+
+    [JsonPropertyName("assignees")]
+    public LinkedBranchAssigneeConnection? Assignees { get; init; }
+
+    [JsonPropertyName("linkedBranches")]
+    public LinkedBranchConnection? LinkedBranches { get; init; }
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchLabelConnection.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchLabelConnection.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchLabelConnection
+{
+    [JsonPropertyName("nodes")]
+    public IReadOnlyList<LinkedBranchLabelNode> Nodes { get; init; } = [];
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchLabelNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchLabelNode.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchLabelNode
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("color")]
+    public string Color { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchNode.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchNode
+{
+    [JsonPropertyName("ref")]
+    public LinkedBranchRef? Ref { get; init; }
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchQueryData.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchQueryData.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchQueryData
+{
+    [JsonPropertyName("repository")]
+    public LinkedBranchRepositoryNode? Repository { get; init; }
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchRef.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchRef.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchRef
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/GhCli.Net/Issues/GraphQL/LinkedBranchRepositoryNode.cs
+++ b/src/GhCli.Net/Issues/GraphQL/LinkedBranchRepositoryNode.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GhCli.Net.Issues.GraphQL;
+
+internal class LinkedBranchRepositoryNode
+{
+    [JsonPropertyName("issue")]
+    public LinkedBranchIssueNode? Issue { get; init; }
+}

--- a/src/GhCli.Net/Issues/IssueClient.cs
+++ b/src/GhCli.Net/Issues/IssueClient.cs
@@ -3,6 +3,7 @@ using GhCli.Net.GraphQL;
 using GhCli.Net.Issues.GraphQL;
 using GhCli.Net.Issues.Models;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace GhCli.Net.Issues;
 
@@ -19,6 +20,20 @@ internal class IssueClient(IGhCliRunner runner) : IIssueClient
             id
             labels(first: 100) {
               nodes { id name }
+            }
+          }
+        }
+        """;
+
+    private const string LinkedBranchQuery = """
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              number title state url body createdAt updatedAt
+              author { login }
+              labels(first: 25) { nodes { name color } }
+              assignees(first: 25) { nodes { login } }
+              linkedBranches(first: 10) { nodes { ref { name } } }
             }
           }
         }
@@ -72,6 +87,56 @@ internal class IssueClient(IGhCliRunner runner) : IIssueClient
 
         return JsonSerializer.Deserialize<IssueDetail>(json, JsonOptions)
             ?? throw new InvalidOperationException($"Issue #{number} konnte nicht abgerufen werden.");
+    }
+
+    public async Task<IssueDetail?> GetLinkedIssueForBranchAsync(string owner, string repo, string branchName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branchName);
+
+        var match = Regex.Match(branchName, @"^(\d+)-");
+        if (!match.Success)
+            return null;
+
+        var number = int.Parse(match.Groups[1].Value);
+
+        var json = await runner.RunAsync(
+            "api", "graphql",
+            "-f", $"query={LinkedBranchQuery}",
+            "-f", $"owner={owner}",
+            "-f", $"repo={repo}",
+            "-F", $"number={number}");
+
+        var response = JsonSerializer.Deserialize<GraphQlResponse<LinkedBranchQueryData>>(json, JsonOptions);
+        var issue = response?.Data?.Repository?.Issue;
+
+        if (issue is null)
+            return null;
+
+        var isLinked = issue.LinkedBranches?.Nodes
+            .Any(n => string.Equals(n.Ref?.Name, branchName, StringComparison.OrdinalIgnoreCase)) ?? false;
+
+        if (!isLinked)
+            return null;
+
+        return new IssueDetail
+        {
+            Number = issue.Number,
+            Title = issue.Title,
+            State = issue.State,
+            Url = issue.Url,
+            Body = issue.Body,
+            CreatedAt = issue.CreatedAt,
+            UpdatedAt = issue.UpdatedAt,
+            Author = new IssueAuthor { Login = issue.Author?.Login ?? string.Empty },
+            Labels = issue.Labels?.Nodes
+                .Select(l => new IssueLabel { Name = l.Name, Color = l.Color })
+                .ToList() ?? [],
+            Assignees = issue.Assignees?.Nodes
+                .Select(a => new IssueAssignee { Login = a.Login })
+                .ToList() ?? [],
+        };
     }
 
     public async Task<Issue> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null)


### PR DESCRIPTION
## Summary

- Neue Methode `GetLinkedIssueForBranchAsync` in `IIssueClient` und `IssueClient`
- GitHub GraphQL Query für `linkedBranches` implementiert (parst Issue-Nummer aus Branch-Namen, verifiziert Verknüpfung)
- 10 neue GraphQL-Model-Klassen in `Issues/GraphQL/`

## Test plan

- [ ] Branch `164-test` ist mit Issue #164 verknüpft → Methode gibt `IssueDetail` zurück
- [ ] Branch ohne Issue-Nummer im Namen → gibt `null` zurück
- [ ] Branch mit Nummer aber ohne GitHub-Verknüpfung → gibt `null` zurück

Closes #165