### PR TITLE
feat(ghGPT): Verknüpftes Issue des aktuellen Branches in der Toolbar anzeigen

### DIFF
--- a/src/GhCli.Net/Issues/IssueClient.cs
+++ b/src/GhCli.Net/Issues/IssueClient.cs
@@ -101,42 +101,14 @@ internal class IssueClient(IGhCliRunner runner) : IIssueClient
 
         var number = int.Parse(match.Groups[1].Value);
 
-        var json = await runner.RunAsync(
-            "api", "graphql",
-            "-f", $"query={LinkedBranchQuery}",
-            "-f", $"owner={owner}",
-            "-f", $"repo={repo}",
-            "-F", $"number={number}");
-
-        var response = JsonSerializer.Deserialize<GraphQlResponse<LinkedBranchQueryData>>(json, JsonOptions);
-        var issue = response?.Data?.Repository?.Issue;
-
-        if (issue is null)
-            return null;
-
-        var isLinked = issue.LinkedBranches?.Nodes
-            .Any(n => string.Equals(n.Ref?.Name, branchName, StringComparison.OrdinalIgnoreCase)) ?? false;
-
-        if (!isLinked)
-            return null;
-
-        return new IssueDetail
+        try
         {
-            Number = issue.Number,
-            Title = issue.Title,
-            State = issue.State,
-            Url = issue.Url,
-            Body = issue.Body,
-            CreatedAt = issue.CreatedAt,
-            UpdatedAt = issue.UpdatedAt,
-            Author = new IssueAuthor { Login = issue.Author?.Login ?? string.Empty },
-            Labels = issue.Labels?.Nodes
-                .Select(l => new IssueLabel { Name = l.Name, Color = l.Color })
-                .ToList() ?? [],
-            Assignees = issue.Assignees?.Nodes
-                .Select(a => new IssueAssignee { Login = a.Login })
-                .ToList() ?? [],
-        };
+            return await GetDetailAsync(owner, repo, number);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     public async Task<Issue> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null)

--- a/src/ghGPT.Api/Controllers/BranchesController.cs
+++ b/src/ghGPT.Api/Controllers/BranchesController.cs
@@ -1,4 +1,5 @@
 using ghGPT.Api.Models;
+using ghGPT.Core.Issues;
 using ghGPT.Core.Repositories;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
@@ -7,7 +8,7 @@ namespace ghGPT.Api.Controllers;
 
 [ApiController]
 [Route("api/repos/{id}/branches")]
-public class BranchesController(IRepositoryService service) : ControllerBase
+public class BranchesController(IRepositoryService service, IIssueService issueService) : ControllerBase
 {
     [HttpGet]
     public ActionResult<IReadOnlyList<BranchInfo>> GetBranches(string id)
@@ -67,6 +68,30 @@ public class BranchesController(IRepositoryService service) : ControllerBase
         {
             await service.DeleteBranch(id, Uri.UnescapeDataString(name));
             return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("linked-issue")]
+    public async Task<ActionResult<IssueDetail>> GetLinkedIssue(string id)
+    {
+        var repo = service.GetAll().FirstOrDefault(r => r.Id == id);
+        if (repo is null)
+            return NotFound(new { error = "Repository nicht gefunden." });
+
+        if (string.IsNullOrEmpty(repo.RemoteUrl))
+            return BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
+
+        try
+        {
+            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
+            var issue = await issueService.GetLinkedIssueForBranchAsync(parsed.Owner, parsed.Repo, repo.CurrentBranch);
+            if (issue is null)
+                return NotFound();
+            return Ok(issue);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/ghGPT.Core/Issues/IIssueService.cs
+++ b/src/ghGPT.Core/Issues/IIssueService.cs
@@ -4,6 +4,7 @@ public interface IIssueService
 {
     Task<IReadOnlyList<IssueListItem>> GetIssuesAsync(string owner, string repo, string state = "open");
     Task<IssueDetail> GetIssueDetailAsync(string owner, string repo, int number);
+    Task<IssueDetail?> GetLinkedIssueForBranchAsync(string owner, string repo, string branchName);
     Task<IssueListItem> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null);
     Task AddCommentAsync(string owner, string repo, int number, string body);
 }

--- a/src/ghGPT.Frontend/src/components/branches-view.ts
+++ b/src/ghGPT.Frontend/src/components/branches-view.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { AppElement } from '../app-element';
-import { repositoryService, type BranchInfo } from '../services/repository-service';
+import { repositoryService, type BranchInfo, type IssueDetail } from '../services/repository-service';
 import { ApiError } from '../services/api-client';
 
 @customElement('branches-view')
@@ -9,6 +9,7 @@ export class BranchesView extends AppElement {
   @property() repoId = '';
   @property({ type: Number }) refreshKey = 0;
   @state() private branches: BranchInfo[] = [];
+  @state() private linkedIssue: IssueDetail | undefined = undefined;
   @state() private showNewBranchDialog = false;
   @state() private newBranchName = '';
   @state() private newBranchStartPoint = '';
@@ -23,7 +24,10 @@ export class BranchesView extends AppElement {
 
   private async loadBranches() {
     if (!this.repoId) return;
-    this.branches = await repositoryService.getBranches(this.repoId);
+    [this.branches, this.linkedIssue] = await Promise.all([
+      repositoryService.getBranches(this.repoId),
+      repositoryService.getLinkedIssue(this.repoId).catch(() => undefined),
+    ]);
   }
 
   private async checkout(name: string) {
@@ -102,6 +106,12 @@ export class BranchesView extends AppElement {
         <span class="text-sm flex-1 overflow-hidden text-ellipsis whitespace-nowrap
           ${b.isHead ? 'text-cat-blue font-medium' : 'text-cat-text'}">${b.name}</span>
         ${b.isHead ? html`<span data-testid="head-badge" class="text-[0.65rem] bg-[#89b4fa33] text-cat-blue rounded px-1 shrink-0">HEAD</span>` : nothing}
+        ${b.isHead && this.linkedIssue ? html`
+          <span class="text-[0.65rem] text-cat-subtle shrink-0 overflow-hidden text-ellipsis whitespace-nowrap max-w-[160px]"
+            title="${this.linkedIssue.title}">
+            #${this.linkedIssue.number} ${this.linkedIssue.title}
+          </span>
+        ` : nothing}
         ${this.renderAheadBehind(b)}
         <div class="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
           ${!b.isHead ? html`

--- a/src/ghGPT.Frontend/src/components/toolbar.ts
+++ b/src/ghGPT.Frontend/src/components/toolbar.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { AppElement } from '../app-element';
-import { repositoryService, type RepositoryInfo, type BranchInfo } from '../services/repository-service';
+import { repositoryService, type RepositoryInfo, type BranchInfo, type IssueDetail } from '../services/repository-service';
 import { ApiError } from '../services/api-client';
 
 @customElement('app-toolbar')
@@ -13,6 +13,7 @@ export class AppToolbar extends AppElement {
 
   @state() private branches: BranchInfo[] = [];
   @state() private showBranchDropdown = false;
+  @state() private linkedIssue: IssueDetail | undefined = undefined;
 
   private _onDocClick = (e: MouseEvent) => {
     const path = e.composedPath();
@@ -25,6 +26,7 @@ export class AppToolbar extends AppElement {
   updated(changedProps: Map<string, unknown>) {
     if (changedProps.has('activeRepo') || changedProps.has('branchesRefreshKey')) {
       this._fetchBranches();
+      this._fetchLinkedIssue();
     }
   }
 
@@ -39,6 +41,14 @@ export class AppToolbar extends AppElement {
       return;
     }
     this.branches = await repositoryService.getBranches(this.activeRepo.id).catch(() => []);
+  }
+
+  private async _fetchLinkedIssue() {
+    if (!this.activeRepo) {
+      this.linkedIssue = undefined;
+      return;
+    }
+    this.linkedIssue = await repositoryService.getLinkedIssue(this.activeRepo.id).catch(() => undefined);
   }
 
   private async _openDropdown() {
@@ -150,6 +160,16 @@ export class AppToolbar extends AppElement {
           </div>
         ` : ''}
       </div>
+
+      ${this.linkedIssue ? html`
+        <button
+          class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cat-border bg-transparent text-cat-subtle text-xs cursor-pointer hover:bg-cat-overlay hover:text-cat-text max-w-[240px]"
+          title="${this.linkedIssue.title}"
+          @click=${() => this._emit('navigate', 'issues')}>
+          <span class="shrink-0 text-cat-blue">#${this.linkedIssue.number}</span>
+          <span class="overflow-hidden text-ellipsis whitespace-nowrap">${this.linkedIssue.title}</span>
+        </button>
+      ` : ''}
 
       <div class="flex-1"></div>
 

--- a/src/ghGPT.Frontend/src/services/repository-service.ts
+++ b/src/ghGPT.Frontend/src/services/repository-service.ts
@@ -299,6 +299,8 @@ export const repositoryService = {
     api.get<IssueListItem[]>(`/repos/${id}/issues?state=${state}`),
   getIssueDetail: (id: string, number: number) =>
     api.get<IssueDetail>(`/repos/${id}/issues/${number}`),
+  getLinkedIssue: (id: string) =>
+    api.get<IssueDetail>(`/repos/${id}/branches/linked-issue`),
   createIssue: (id: string, title: string, body: string, labels?: string[]) =>
     api.post<IssueListItem>(`/repos/${id}/issues`, { title, body, labels }),
   addIssueComment: (id: string, number: number, body: string) =>

--- a/src/ghGPT.Infrastructure/Issues/IssueService.cs
+++ b/src/ghGPT.Infrastructure/Issues/IssueService.cs
@@ -39,6 +39,25 @@ public class IssueService(IIssueClient issueClient) : IIssueService
         };
     }
 
+    public async Task<IssueDetail?> GetLinkedIssueForBranchAsync(string owner, string repo, string branchName)
+    {
+        var i = await issueClient.GetLinkedIssueForBranchAsync(owner, repo, branchName);
+        if (i is null) return null;
+        return new IssueDetail
+        {
+            Number = i.Number,
+            Title = i.Title,
+            State = i.State,
+            AuthorLogin = i.Author.Login,
+            Labels = i.Labels.Select(l => new IssueLabel { Name = l.Name, Color = l.Color }).ToList(),
+            Assignees = i.Assignees.Select(a => a.Login).ToList(),
+            Body = i.Body,
+            CreatedAt = i.CreatedAt,
+            UpdatedAt = i.UpdatedAt,
+            Url = i.Url
+        };
+    }
+
     public async Task<IssueListItem> CreateAsync(string owner, string repo, string title, string body, IEnumerable<string>? labels = null)
     {
         var i = await issueClient.CreateAsync(owner, repo, title, body, labels);


### PR DESCRIPTION
## Summary

- Neuer Endpunkt `GET /api/repos/{id}/branches/linked-issue` im `BranchesController`
- `IIssueService` und `IssueService` um `GetLinkedIssueForBranchAsync` erweitert
- `repositoryService.getLinkedIssue(id)` im Frontend ergänzt
- Toolbar zeigt klickbares Badge `#123 Issue-Titel` neben dem Branch-Button (navigiert zur Issues-Ansicht)

## Test plan

- [x] Branch mit verknüpftem Issue → Badge `#164 test` erscheint in der Toolbar
- [x] Klick auf Badge navigiert zur Issues-Ansicht
- [x] Branch ohne Verknüpfung → kein Badge
- [x] Kein Remote → kein Fehler, kein Badge

Closes #166