### PR TITLE
feat: verknüpftes Issue als Kontext für KI-Commit-Nachricht nutzen

### DIFF
--- a/src/ghGPT.Ai/CommitMessageService.cs
+++ b/src/ghGPT.Ai/CommitMessageService.cs
@@ -13,6 +13,9 @@ internal sealed class CommitMessageService(
 
     public async IAsyncEnumerable<string> StreamCommitMessageAsync(
         string repoId,
+        int? linkedIssueNumber = null,
+        string? linkedIssueTitle = null,
+        string? linkedIssueBody = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var diff = BuildStagedDiff(repoId);
@@ -20,7 +23,7 @@ internal sealed class CommitMessageService(
 
         var messages = new List<ChatMessage>
         {
-            new() { Role = "system", Content = BuildSystemPrompt(recentCommits) },
+            new() { Role = "system", Content = BuildSystemPrompt(recentCommits, linkedIssueNumber, linkedIssueTitle, linkedIssueBody) },
             new() { Role = "user", Content = BuildUserPrompt(diff, recentCommits) }
         };
 
@@ -28,7 +31,11 @@ internal sealed class CommitMessageService(
             yield return token;
     }
 
-    private string BuildSystemPrompt(IReadOnlyList<string> recentCommits)
+    private string BuildSystemPrompt(
+        IReadOnlyList<string> recentCommits,
+        int? linkedIssueNumber,
+        string? linkedIssueTitle,
+        string? linkedIssueBody)
     {
         var sb = new StringBuilder();
         sb.AppendLine("Du bist ein präziser Git-Assistent. Deine einzige Aufgabe ist es, eine einzelne Commit-Nachricht zu generieren.");
@@ -51,6 +58,14 @@ internal sealed class CommitMessageService(
         sb.AppendLine("- Scope: optional, beschreibt das Modul/die Komponente (z.B. 'api', 'ui', 'auth')");
         sb.AppendLine("- Body: nur wenn der Diff allein nicht erklärt warum — nicht was");
         sb.AppendLine("- Keine Issue-Referenzen hinzufügen");
+
+        if (linkedIssueNumber.HasValue && !string.IsNullOrWhiteSpace(linkedIssueTitle))
+        {
+            sb.AppendLine();
+            sb.AppendLine($"FEATURE-KONTEXT (Issue #{linkedIssueNumber}: {linkedIssueTitle}):");
+            if (!string.IsNullOrWhiteSpace(linkedIssueBody))
+                sb.AppendLine(linkedIssueBody.Trim());
+        }
 
         if (recentCommits.Count > 0)
         {

--- a/src/ghGPT.Api/Controllers/CommitMessageController.cs
+++ b/src/ghGPT.Api/Controllers/CommitMessageController.cs
@@ -1,3 +1,4 @@
+using ghGPT.Api.Models;
 using ghGPT.Core.Ai;
 using Microsoft.AspNetCore.Mvc;
 using System.Text;
@@ -10,7 +11,7 @@ namespace ghGPT.Api.Controllers;
 public class CommitMessageController(ICommitMessageService commitMessageService) : ControllerBase
 {
     [HttpPost("commit-message")]
-    public async Task StreamCommitMessage(string id, CancellationToken cancellationToken)
+    public async Task StreamCommitMessage(string id, [FromBody] CommitMessageRequest? request, CancellationToken cancellationToken)
     {
         Response.Headers.ContentType = "text/event-stream";
         Response.Headers.CacheControl = "no-cache";
@@ -20,7 +21,12 @@ public class CommitMessageController(ICommitMessageService commitMessageService)
 
         try
         {
-            await foreach (var token in commitMessageService.StreamCommitMessageAsync(id, cancellationToken))
+            await foreach (var token in commitMessageService.StreamCommitMessageAsync(
+                id,
+                request?.LinkedIssueNumber,
+                request?.LinkedIssueTitle,
+                request?.LinkedIssueBody,
+                cancellationToken))
             {
                 var data = JsonSerializer.Serialize(token);
                 var bytes = Encoding.UTF8.GetBytes($"data: {data}\n\n");

--- a/src/ghGPT.Api/Models/CommitMessageRequest.cs
+++ b/src/ghGPT.Api/Models/CommitMessageRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace ghGPT.Api.Models;
+
+public sealed class CommitMessageRequest
+{
+    [JsonPropertyName("linkedIssueNumber")]
+    public int? LinkedIssueNumber { get; init; }
+
+    [JsonPropertyName("linkedIssueTitle")]
+    public string? LinkedIssueTitle { get; init; }
+
+    [JsonPropertyName("linkedIssueBody")]
+    public string? LinkedIssueBody { get; init; }
+}

--- a/src/ghGPT.Core/Ai/ICommitMessageService.cs
+++ b/src/ghGPT.Core/Ai/ICommitMessageService.cs
@@ -2,5 +2,10 @@ namespace ghGPT.Core.Ai;
 
 public interface ICommitMessageService
 {
-    IAsyncEnumerable<string> StreamCommitMessageAsync(string repoId, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<string> StreamCommitMessageAsync(
+        string repoId,
+        int? linkedIssueNumber = null,
+        string? linkedIssueTitle = null,
+        string? linkedIssueBody = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ghGPT.Frontend/src/components/changes-view.ts
+++ b/src/ghGPT.Frontend/src/components/changes-view.ts
@@ -12,7 +12,7 @@ const REVIEW_PURIFY_CONFIG = {
                  'ul', 'ol', 'li', 'blockquote'],
   ALLOWED_ATTR: ['href', 'title', 'rel'],
 };
-import { repositoryService, type FileStatusEntry, type RepositoryStatusResult } from '../services/repository-service';
+import { repositoryService, type FileStatusEntry, type IssueDetail, type RepositoryStatusResult } from '../services/repository-service';
 
 interface ParsedHunk {
   oldStart: number;
@@ -52,6 +52,7 @@ export class ChangesView extends AppElement {
   @state() private commitError = '';
   @state() private committing = false;
   @state() private lineActionInProgress = false;
+  @state() private linkedIssue: IssueDetail | undefined = undefined;
   @state() private stashing = false;
   @state() private stashError = '';
   @state() private discardConfirmPath = '';
@@ -69,6 +70,7 @@ export class ChangesView extends AppElement {
       this._orderedPaths = [];
       this.resetReviewState();
       this.loadStatus();
+      this._fetchLinkedIssue();
     } else if (changed.has('refreshKey') && this.repoId) {
       this.resetReviewState();
       const prevPath = this.selectedPath;
@@ -348,15 +350,29 @@ export class ChangesView extends AppElement {
     }
   }
 
+  private async _fetchLinkedIssue() {
+    this.linkedIssue = await repositoryService.getLinkedIssue(this.repoId).catch(() => undefined);
+  }
+
   private async generateCommitMessage() {
     if (this.generatingMessage || this.status.staged.length === 0) return;
     this.generatingMessage = true;
     this.aiStreamPreview = '';
     this.commitMessage = '';
 
+    const body = this.linkedIssue
+      ? JSON.stringify({
+          linkedIssueNumber: this.linkedIssue.number,
+          linkedIssueTitle: this.linkedIssue.title,
+          linkedIssueBody: this.linkedIssue.body,
+        })
+      : undefined;
+
     try {
       const response = await fetch(`/api/repos/${encodeURIComponent(this.repoId)}/ai/commit-message`, {
         method: 'POST',
+        headers: body ? { 'Content-Type': 'application/json' } : {},
+        body,
       });
       if (!response.ok || !response.body) throw new Error('Anfrage fehlgeschlagen');
 


### PR DESCRIPTION
Closes #169

## Summary

- `ICommitMessageService.StreamCommitMessageAsync` um optionale Issue-Parameter (`linkedIssueNumber`, `linkedIssueTitle`, `linkedIssueBody`) erweitert
- `CommitMessageService` integriert Issue-Titel und -Body als `FEATURE-KONTEXT`-Abschnitt im System-Prompt
- `CommitMessageController` liest optionalen JSON-Body (`CommitMessageRequest`) aus und reicht Issue-Daten weiter
- `changes-view.ts` fetcht das verknüpfte Issue beim Repo-Wechsel und schickt es im POST-Body mit

## Test plan

- [ ] Commit-Nachricht generieren **mit** verknüpftem Issue → Issue-Kontext sollte in der Nachricht erkennbar sein
- [ ] Commit-Nachricht generieren **ohne** verknüpftes Issue → funktioniert wie bisher