### PR TITLE
refactor(ollama): IHttpClientFactory statt eigenem HttpClient

### DIFF
--- a/src/ghGPT.Ai.Ollama/DependencyInjection.cs
+++ b/src/ghGPT.Ai.Ollama/DependencyInjection.cs
@@ -7,6 +7,10 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddOllamaClient(this IServiceCollection services)
     {
+        services.AddHttpClient("Ollama", client =>
+        {
+            client.Timeout = TimeSpan.FromMinutes(10);
+        });
         services.AddSingleton<IOllamaClient, OllamaClient>();
         services.AddSingleton<IAiProviderService, OllamaProviderService>();
         return services;

--- a/src/ghGPT.Ai.Ollama/OllamaClient.cs
+++ b/src/ghGPT.Ai.Ollama/OllamaClient.cs
@@ -9,10 +9,10 @@ namespace ghGPT.Ai.Ollama;
 
 internal sealed class OllamaClient(
     IAiSettingsService settingsService,
-    ILogger<OllamaClient> logger,
-    HttpClient? httpClient = null) : IOllamaClient
+    IHttpClientFactory httpClientFactory,
+    ILogger<OllamaClient> logger) : IOllamaClient
 {
-    private readonly HttpClient _http = httpClient ?? new() { Timeout = TimeSpan.FromMinutes(10) };
+    private HttpClient CreateHttpClient() => httpClientFactory.CreateClient("Ollama");
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -25,8 +25,9 @@ internal sealed class OllamaClient(
         var settings = settingsService.Load();
         try
         {
+            using var http = CreateHttpClient();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            var response = await _http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/v1/models", cts.Token);
+            var response = await http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/v1/models", cts.Token);
             return response.IsSuccessStatusCode;
         }
         catch (Exception ex)
@@ -39,8 +40,9 @@ internal sealed class OllamaClient(
     public async Task<IReadOnlyList<AiModelInfo>> GetModelsAsync()
     {
         var settings = settingsService.Load();
+        using var http = CreateHttpClient();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var response = await _http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/v1/models", cts.Token);
+        var response = await http.GetAsync($"{settings.BaseUrl.TrimEnd('/')}/v1/models", cts.Token);
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<OpenAiModelsResponse>();
@@ -65,12 +67,13 @@ internal sealed class OllamaClient(
             stream = true
         };
 
+        using var http = CreateHttpClient();
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{settings.BaseUrl.TrimEnd('/')}/v1/chat/completions")
         {
             Content = JsonContent.Create(requestBody)
         };
 
-        using var response = await SendAsync(request, cancellationToken);
+        using var response = await SendAsync(http, request, cancellationToken);
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
 
         await foreach (var token in OllamaSseParser.ParseTokensAsync(stream, cancellationToken))
@@ -101,12 +104,13 @@ internal sealed class OllamaClient(
             stream = false
         };
 
+        using var http = CreateHttpClient();
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{settings.BaseUrl.TrimEnd('/')}/v1/chat/completions")
         {
             Content = JsonContent.Create(requestBody)
         };
 
-        using var response = await SendAsync(request, cancellationToken);
+        using var response = await SendAsync(http, request, cancellationToken);
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
         var completion = JsonSerializer.Deserialize<OpenAiCompletion>(json);
@@ -130,9 +134,9 @@ internal sealed class OllamaClient(
         return new ToolCallResponse { Content = choice.Message?.Content ?? string.Empty };
     }
 
-    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    private static async Task<HttpResponseMessage> SendAsync(HttpClient http, HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
         return response;
     }

--- a/src/ghGPT.Ai.Ollama/ghGPT.Ai.Ollama.csproj
+++ b/src/ghGPT.Ai.Ollama/ghGPT.Ai.Ollama.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
   </ItemGroup>
 

--- a/tests/ghGPT.Ai.Tests/OllamaClientTests.cs
+++ b/tests/ghGPT.Ai.Tests/OllamaClientTests.cs
@@ -46,7 +46,7 @@ public class OllamaClientTests
     public async Task IsAvailableAsync_WhenConnectionFails_ReturnsFalse()
     {
         var handler = new ThrowingHttpMessageHandler(new HttpRequestException("connection refused"));
-        var sut = new OllamaClient(_settingsService, NullLogger<OllamaClient>.Instance, new HttpClient(handler));
+        var sut = CreateClient(handler);
 
         var result = await sut.IsAvailableAsync();
 
@@ -307,7 +307,14 @@ public class OllamaClientTests
     private OllamaClient CreateClient(HttpStatusCode statusCode, string body)
     {
         var handler = new FakeHttpMessageHandler(statusCode, body);
-        return new OllamaClient(_settingsService, NullLogger<OllamaClient>.Instance, new HttpClient(handler));
+        return CreateClient(handler);
+    }
+
+    private OllamaClient CreateClient(HttpMessageHandler handler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("Ollama").Returns(new HttpClient(handler));
+        return new OllamaClient(_settingsService, factory, NullLogger<OllamaClient>.Instance);
     }
 
     private static async Task<List<string>> CollectTokensAsync(OllamaClient client)


### PR DESCRIPTION
## Summary

Closes #176

- `OllamaClient` verwendet nun `IHttpClientFactory` mit Named Client `"Ollama"` statt einen eigenen `HttpClient` zu instanziieren
- Timeout (10 Min) wird über `AddHttpClient` konfiguriert
- `Microsoft.Extensions.Http` als Dependency hinzugefügt
- Tests nutzen gemockte `IHttpClientFactory` mit `FakeHttpMessageHandler`

## Warum

- **Socket-Exhaustion verhindern**: `HttpClient` wird nicht mehr manuell erstellt, sondern über den Connection-Pool der Factory verwaltet
- **Testbarkeit**: `IHttpClientFactory` ist sauber mockbar
- **Best Practice**: [Microsoft: IHttpClientFactory](https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory)

## Test plan

- [x] Alle 275 Tests grün
- [x] Build ohne Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)