### PR TITLE
test(frontend): Unit-Tests für Lit.js-Services einführen

### DIFF
--- a/src/ghGPT.Frontend/package-lock.json
+++ b/src/ghGPT.Frontend/package-lock.json
@@ -18,7 +18,8 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "typescript": "~5.9.3",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -412,6 +413,13 @@
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -679,11 +687,149 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -696,6 +842,33 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -728,6 +901,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -742,6 +932,16 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -1141,6 +1341,24 @@
         }
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1152,7 +1370,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1307,6 +1524,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1315,6 +1539,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
@@ -1335,6 +1573,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1349,6 +1604,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tough-cookie": {
@@ -1417,7 +1682,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1490,6 +1754,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1504,6 +1858,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/src/ghGPT.Frontend/package.json
+++ b/src/ghGPT.Frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -21,6 +23,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "typescript": "~5.9.3",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/ghGPT.Frontend/src/__tests__/api-client.test.ts
+++ b/src/ghGPT.Frontend/src/__tests__/api-client.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../services/api-client';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockOk(body: string, status = 200): Response {
+  return {
+    ok: true,
+    status,
+    statusText: 'OK',
+    text: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function mockError(status: number, body: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText: 'Error',
+    text: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('ApiError', () => {
+  it('has name ApiError', () => {
+    const err = new ApiError('Not found', 404);
+    expect(err.name).toBe('ApiError');
+  });
+
+  it('stores status code', () => {
+    const err = new ApiError('Unauthorized', 401);
+    expect(err.status).toBe(401);
+  });
+
+  it('stores message', () => {
+    const err = new ApiError('Server error', 500);
+    expect(err.message).toBe('Server error');
+  });
+
+  it('is an instance of Error', () => {
+    expect(new ApiError('x', 400)).toBeInstanceOf(Error);
+  });
+});
+
+describe('api.get', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('calls fetch with correct URL and Content-Type header', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk('{}'));
+    await api.get('/repos');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    );
+  });
+
+  it('returns parsed JSON on success', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk('{"id":"1","name":"repo"}'));
+    const result = await api.get<{ id: string; name: string }>('/repos/1');
+    expect(result).toEqual({ id: '1', name: 'repo' });
+  });
+
+  it('returns undefined for empty response body', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk('', 204));
+    const result = await api.get<void>('/repos/1/fetch');
+    expect(result).toBeUndefined();
+  });
+
+  it('throws ApiError with status 404 on not-found response', async () => {
+    mockFetch.mockResolvedValueOnce(mockError(404, '{"error":"not found"}'));
+    await expect(api.get('/repos/bad')).rejects.toMatchObject({
+      status: 404,
+      message: 'not found',
+    });
+  });
+
+  it('throws ApiError using title field when error field absent', async () => {
+    mockFetch.mockResolvedValueOnce(mockError(400, '{"title":"Bad Request"}'));
+    await expect(api.get('/repos/bad')).rejects.toMatchObject({
+      status: 400,
+      message: 'Bad Request',
+    });
+  });
+
+  it('throws ApiError with plain text when response is not JSON', async () => {
+    mockFetch.mockResolvedValueOnce(mockError(500, 'Internal Server Error'));
+    await expect(api.get('/repos')).rejects.toMatchObject({
+      status: 500,
+      message: 'Internal Server Error',
+    });
+  });
+});
+
+describe('api.post', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('calls fetch with POST method', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk('{"id":"1"}'));
+    await api.post('/repos', { name: 'my-repo' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('serializes body as JSON', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk(''));
+    await api.post('/repos', { name: 'my-repo', localPath: '/tmp' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos',
+      expect.objectContaining({ body: JSON.stringify({ name: 'my-repo', localPath: '/tmp' }) }),
+    );
+  });
+
+  it('sends no body when body argument is undefined', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk(''));
+    await api.post('/repos/1/fetch');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos/1/fetch',
+      expect.objectContaining({ body: undefined }),
+    );
+  });
+});
+
+describe('api.put', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('calls fetch with PUT method', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk(''));
+    await api.put('/repos/active/id-1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos/active/id-1',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+});
+
+describe('api.delete', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('calls fetch with DELETE method', async () => {
+    mockFetch.mockResolvedValueOnce(mockOk(''));
+    await api.delete('/repos/1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/repos/1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});

--- a/src/ghGPT.Frontend/src/__tests__/repository-service.test.ts
+++ b/src/ghGPT.Frontend/src/__tests__/repository-service.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/api-client', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue(undefined),
+    post: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    patch: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => { storage[key] = value; },
+  removeItem: (key: string) => { delete storage[key]; },
+  clear: () => { for (const key of Object.keys(storage)) delete storage[key]; },
+});
+
+import { api } from '../services/api-client';
+import { repositoryService } from '../services/repository-service';
+
+const mockApi = api as { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn>; patch: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+
+describe('repositoryService — URL construction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('getAll calls GET /repos', async () => {
+    await repositoryService.getAll();
+    expect(mockApi.get).toHaveBeenCalledWith('/repos');
+  });
+
+  it('getStatus calls GET /repos/{id}/status', async () => {
+    await repositoryService.getStatus('repo-1');
+    expect(mockApi.get).toHaveBeenCalledWith('/repos/repo-1/status');
+  });
+
+  it('setActive calls PUT /repos/active/{id}', async () => {
+    await repositoryService.setActive('repo-1');
+    expect(mockApi.put).toHaveBeenCalledWith('/repos/active/repo-1');
+  });
+
+  it('remove calls DELETE /repos/{id}', async () => {
+    await repositoryService.remove('repo-1');
+    expect(mockApi.delete).toHaveBeenCalledWith('/repos/repo-1');
+  });
+
+  it('stageFile encodes file path in URL', async () => {
+    await repositoryService.stageFile('repo-1', 'src/my file.ts');
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/repos/repo-1/stage?file=src%2Fmy%20file.ts',
+    );
+  });
+
+  it('getDiff encodes file path and passes staged flag', async () => {
+    await repositoryService.getDiff('repo-1', 'src/app.ts', true);
+    expect(mockApi.get).toHaveBeenCalledWith(
+      '/repos/repo-1/diff?file=src%2Fapp.ts&staged=true',
+    );
+  });
+
+  it('deleteBranch encodes branch name in URL', async () => {
+    await repositoryService.deleteBranch('repo-1', 'origin/feature/x');
+    expect(mockApi.delete).toHaveBeenCalledWith(
+      '/repos/repo-1/branches/origin%2Ffeature%2Fx',
+    );
+  });
+
+  it('getCommits builds correct query params', async () => {
+    await repositoryService.getCommits('repo-1', 'main', 0, 50);
+    expect(mockApi.get).toHaveBeenCalledWith(
+      expect.stringContaining('/repos/repo-1/commits?'),
+    );
+    const url = mockApi.get.mock.calls[0][0] as string;
+    expect(url).toContain('skip=0');
+    expect(url).toContain('take=50');
+    expect(url).toContain('branch=main');
+  });
+
+  it('getCommits omits branch param when not provided', async () => {
+    await repositoryService.getCommits('repo-1');
+    const url = mockApi.get.mock.calls[0][0] as string;
+    expect(url).not.toContain('branch=');
+  });
+
+  it('commit posts message and description', async () => {
+    await repositoryService.commit('repo-1', 'feat: test', 'description text');
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/repos/repo-1/commit',
+      { message: 'feat: test', description: 'description text' },
+    );
+  });
+
+  it('checkoutBranch uses PUT with strategy defaulting to Normal', async () => {
+    await repositoryService.checkoutBranch('repo-1', 'feature/x');
+    expect(mockApi.put).toHaveBeenCalledWith(
+      '/repos/repo-1/branches/checkout',
+      { name: 'feature/x', strategy: 'Normal', stashMessage: undefined },
+    );
+  });
+
+  it('pushStash sends null for empty message and paths', async () => {
+    await repositoryService.pushStash('repo-1');
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/repos/repo-1/stash',
+      { message: null, paths: null },
+    );
+  });
+});
+
+describe('repositoryService — localStorage', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('saveActiveId persists id in localStorage', () => {
+    repositoryService.saveActiveId('repo-42');
+    expect(localStorage.getItem('ghgpt:activeRepoId')).toBe('repo-42');
+  });
+
+  it('loadActiveId returns null when nothing saved', () => {
+    expect(repositoryService.loadActiveId()).toBeNull();
+  });
+
+  it('loadActiveId returns previously saved id', () => {
+    repositoryService.saveActiveId('repo-7');
+    expect(repositoryService.loadActiveId()).toBe('repo-7');
+  });
+
+  it('saveActiveId overwrites previous value', () => {
+    repositoryService.saveActiveId('repo-1');
+    repositoryService.saveActiveId('repo-2');
+    expect(repositoryService.loadActiveId()).toBe('repo-2');
+  });
+});

--- a/src/ghGPT.Frontend/vite.config.ts
+++ b/src/ghGPT.Frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 
@@ -6,5 +7,9 @@ export default defineConfig({
   build: {
     outDir: '../ghGPT.Api/wwwroot',
     emptyOutDir: true,
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- **Vitest** als Unit-Test-Framework eingerichtet (kein Browser nötig, läuft mit `npm test`)
- 2 Test-Dateien für die Service-Schicht: `api-client` und `repository-service`
- `npm test` läuft eigenständig ohne Browser-Infrastruktur

## Neue Tests (31 gesamt)
| Datei | Abdeckung |
|-------|-----------|
| `api-client.test.ts` | `ApiError` (name, status, instanceof), `api.get/post/put/delete` (URL, Headers, Body, Fehlerbehandlung, leere Response) |
| `repository-service.test.ts` | URL-Konstruktion, Query-Parameter-Encoding, Sonderzeichen in Dateipfaden, `localStorage` (save/load/overwrite) |

## Test plan
- [x] `npm test` → 31 Tests grün
- [x] `dotnet test` → alle 323 Tests grün (keine Regression)
- [x] `dotnet build` ohne Fehler

Closes #179