### PR TITLE
feat(pull-requests): PR-Reviews erstellen (Approve / Request Changes / Comment)

### DIFF
--- a/src/ghGPT.Api/Controllers/PullRequestsController.cs
+++ b/src/ghGPT.Api/Controllers/PullRequestsController.cs
@@ -118,6 +118,23 @@ public class PullRequestsController(
         }
     }
 
+    [HttpPost("{number:int}/reviews")]
+    public async Task<IActionResult> CreateReview(string id, int number, [FromBody] CreateReviewRequest request)
+    {
+        if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
+            return error!;
+
+        try
+        {
+            await pullRequestService.CreateReviewAsync(ownerRepo.owner, ownerRepo.repo, number, request.Event, request.Body);
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
     [HttpPost("{number:int}/merge")]
     public async Task<IActionResult> MergePullRequest(string id, int number, [FromBody] MergePullRequestRequest request)
     {
@@ -181,3 +198,7 @@ public record MergePullRequestRequest(
     string Method = "merge",
     string? CommitTitle = null,
     string? CommitBody = null);
+
+public record CreateReviewRequest(
+    string Event,
+    string? Body = null);

--- a/src/ghGPT.Core/PullRequests/IPullRequestService.cs
+++ b/src/ghGPT.Core/PullRequests/IPullRequestService.cs
@@ -9,4 +9,5 @@ public interface IPullRequestService
     Task EditAsync(string owner, string repo, int number, string? title, string? body);
     Task MergeAsync(string owner, string repo, int number, string method, string? commitTitle, string? commitBody);
     Task<PullRequestDetail> CreateAsync(string owner, string repo, string title, string body, string headBranch, string baseBranch, bool draft);
+    Task CreateReviewAsync(string owner, string repo, int number, string reviewEvent, string? body = null);
 }

--- a/src/ghGPT.Frontend/src/components/app-shell.ts
+++ b/src/ghGPT.Frontend/src/components/app-shell.ts
@@ -195,7 +195,7 @@ export class AppShell extends AppElement {
       case 'stashes':
         return html`<stashes-view .repoId=${s.activeRepoId ?? ''} .refreshKey=${this.stashesRefreshKey} @stash-popped=${() => this.changesRefreshKey++}></stashes-view>`;
       case 'pull-requests':
-        return html`<pull-requests-view .repoId=${s.activeRepoId ?? ''}></pull-requests-view>`;
+        return html`<pull-requests-view .repoId=${s.activeRepoId ?? ''} .accountLogin=${s.account?.login ?? ''}></pull-requests-view>`;
       case 'issues':
         return html`<issues-view .repoId=${s.activeRepoId ?? ''}></issues-view>`;
       case 'releases':

--- a/src/ghGPT.Frontend/src/components/pull-requests-view.ts
+++ b/src/ghGPT.Frontend/src/components/pull-requests-view.ts
@@ -10,6 +10,7 @@ import {
 @customElement('pull-requests-view')
 export class PullRequestsView extends AppElement {
   @property() repoId = '';
+  @property() accountLogin = '';
 
   @state() private prs: PullRequestListItem[] = [];
   @state() private selectedPr: PullRequestDetail | null = null;
@@ -520,7 +521,7 @@ export class PullRequestsView extends AppElement {
                 </div>
               ` : ''}
 
-              ${this.selectedPr.state.toLowerCase() === 'open' ? html`
+              ${this.selectedPr.state.toLowerCase() === 'open' && (!this.accountLogin || this.selectedPr.authorLogin !== this.accountLogin) ? html`
                 <div>
                   <div class="flex items-center justify-between mb-2">
                     <div class="text-[0.8rem] font-bold text-cat-subtext uppercase tracking-[0.07em]">Review erstellen</div>

--- a/src/ghGPT.Frontend/src/components/pull-requests-view.ts
+++ b/src/ghGPT.Frontend/src/components/pull-requests-view.ts
@@ -31,6 +31,11 @@ export class PullRequestsView extends AppElement {
   @state() private createHead = '';
   @state() private createBase = '';
   @state() private createDraft = false;
+  @state() private showReviewForm = false;
+  @state() private reviewBody = '';
+  @state() private reviewBusy = false;
+  @state() private reviewError: string | null = null;
+  @state() private reviewSuccess = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -73,6 +78,10 @@ export class PullRequestsView extends AppElement {
     this.showEditForm = false;
     this.showMergeDropdown = false;
     this.showCreateForm = false;
+    this.showReviewForm = false;
+    this.reviewBody = '';
+    this.reviewError = null;
+    this.reviewSuccess = false;
     this.loadingDetail = true;
     try {
       const result = await repositoryService.getPullRequestDetail(requestedRepoId, number);
@@ -185,6 +194,29 @@ export class PullRequestsView extends AppElement {
       this.actionError = e instanceof Error ? e.message : 'Fehler beim Erstellen.';
     } finally {
       this.actionBusy = false;
+    }
+  }
+
+  private async _doReview(event: 'approve' | 'request_changes' | 'comment') {
+    if (!this.selectedNumber) return;
+    if (event !== 'approve' && !this.reviewBody.trim()) {
+      this.reviewError = 'Bitte gib einen Review-Kommentar ein.';
+      return;
+    }
+    this.reviewBusy = true;
+    this.reviewError = null;
+    this.reviewSuccess = false;
+    try {
+      await repositoryService.createPullRequestReview(
+        this.repoId, this.selectedNumber, event, this.reviewBody.trim() || undefined);
+      this.reviewBody = '';
+      this.showReviewForm = false;
+      this.reviewSuccess = true;
+      await this.selectPr(this.selectedNumber);
+    } catch (e: unknown) {
+      this.reviewError = e instanceof Error ? e.message : 'Fehler beim Erstellen des Reviews.';
+    } finally {
+      this.reviewBusy = false;
     }
   }
 
@@ -485,6 +517,67 @@ export class PullRequestsView extends AppElement {
                       </div>
                     `)}
                   </div>
+                </div>
+              ` : ''}
+
+              ${this.selectedPr.state.toLowerCase() === 'open' ? html`
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <div class="text-[0.8rem] font-bold text-cat-subtext uppercase tracking-[0.07em]">Review erstellen</div>
+                    ${!this.showReviewForm ? html`
+                      <button class="px-2.5 py-0.5 text-[0.75rem] border border-cat-muted rounded bg-transparent text-cat-subtext cursor-pointer hover:bg-cat-overlay hover:text-cat-text"
+                        @click=${() => { this.showReviewForm = true; this.reviewError = null; this.reviewSuccess = false; }}>
+                        + Review
+                      </button>
+                    ` : ''}
+                  </div>
+
+                  ${this.reviewSuccess ? html`
+                    <div class="text-cat-green text-[0.8rem] px-3 py-2 bg-[rgba(166,227,161,0.08)] rounded border border-[rgba(166,227,161,0.2)]">
+                      Review erfolgreich abgeschickt.
+                    </div>
+                  ` : ''}
+
+                  ${this.showReviewForm ? html`
+                    <div class="flex flex-col gap-2.5 p-3 bg-cat-base rounded-lg border border-cat-border">
+                      <textarea
+                        class="bg-cat-surface border border-cat-muted rounded-md text-cat-text text-[0.875rem] px-3 py-2 font-[inherit] w-full box-border min-h-[80px] resize-y leading-[1.5] focus:outline-none focus:border-cat-blue"
+                        .value=${this.reviewBody}
+                        @input=${(e: Event) => this.reviewBody = (e.target as HTMLTextAreaElement).value}
+                        placeholder="Review-Kommentar (optional bei Approve, Pflicht bei anderen)..."></textarea>
+
+                      ${this.reviewError ? html`
+                        <div class="text-cat-red text-[0.8rem] px-3 py-1.5 bg-[rgba(243,139,168,0.08)] rounded">${this.reviewError}</div>
+                      ` : ''}
+
+                      <div class="flex gap-2 flex-wrap">
+                        <button
+                          class="flex-1 px-3 py-1.5 text-[0.78rem] border border-cat-green rounded-md bg-transparent text-cat-green cursor-pointer hover:bg-[rgba(166,227,161,0.1)] disabled:opacity-45 disabled:cursor-not-allowed"
+                          ?disabled=${this.reviewBusy}
+                          @click=${() => this._doReview('approve')}>
+                          ${this.reviewBusy ? '…' : '✓ Approve'}
+                        </button>
+                        <button
+                          class="flex-1 px-3 py-1.5 text-[0.78rem] border border-cat-red rounded-md bg-transparent text-cat-red cursor-pointer hover:bg-[rgba(243,139,168,0.1)] disabled:opacity-45 disabled:cursor-not-allowed"
+                          ?disabled=${this.reviewBusy}
+                          @click=${() => this._doReview('request_changes')}>
+                          ${this.reviewBusy ? '…' : '✗ Request Changes'}
+                        </button>
+                        <button
+                          class="flex-1 px-3 py-1.5 text-[0.78rem] border border-cat-blue rounded-md bg-transparent text-cat-blue cursor-pointer hover:bg-[rgba(137,180,250,0.1)] disabled:opacity-45 disabled:cursor-not-allowed"
+                          ?disabled=${this.reviewBusy}
+                          @click=${() => this._doReview('comment')}>
+                          ${this.reviewBusy ? '…' : '💬 Comment'}
+                        </button>
+                        <button
+                          class="px-3 py-1.5 text-[0.78rem] border border-cat-border rounded-md bg-transparent text-cat-subtext cursor-pointer hover:bg-cat-overlay disabled:opacity-45 disabled:cursor-not-allowed"
+                          ?disabled=${this.reviewBusy}
+                          @click=${() => { this.showReviewForm = false; this.reviewError = null; }}>
+                          Abbrechen
+                        </button>
+                      </div>
+                    </div>
+                  ` : ''}
                 </div>
               ` : ''}
             </div>

--- a/src/ghGPT.Frontend/src/services/repository-service.ts
+++ b/src/ghGPT.Frontend/src/services/repository-service.ts
@@ -282,6 +282,8 @@ export const repositoryService = {
     api.patch<void>(`/repos/${id}/pull-requests/${number}/reopen`, {}),
   mergePullRequest: (id: string, number: number, method: 'merge' | 'squash' | 'rebase' = 'merge', commitTitle?: string, commitBody?: string) =>
     api.post<void>(`/repos/${id}/pull-requests/${number}/merge`, { method, commitTitle, commitBody }),
+  createPullRequestReview: (id: string, number: number, event: 'approve' | 'request_changes' | 'comment', body?: string) =>
+    api.post<void>(`/repos/${id}/pull-requests/${number}/reviews`, { event, body }),
 
   getDiscussions: (id: string, limit = 30) =>
     api.get<DiscussionItem[]>(`/repos/${id}/discussions?limit=${limit}`),

--- a/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
+++ b/src/ghGPT.Infrastructure/PullRequests/PullRequestService.cs
@@ -62,6 +62,17 @@ public class PullRequestService(IPullRequestClient pullRequestClient) : IPullReq
         return MapDetail(pr);
     }
 
+    public Task CreateReviewAsync(string owner, string repo, int number, string reviewEvent, string? body = null)
+    {
+        var evt = reviewEvent.ToLowerInvariant() switch
+        {
+            "request_changes" => PullRequestReviewEvent.RequestChanges,
+            "comment" => PullRequestReviewEvent.Comment,
+            _ => PullRequestReviewEvent.Approve
+        };
+        return pullRequestClient.CreateReviewAsync(owner, repo, number, evt, body);
+    }
+
     private static CoreDetail MapDetail(GhCli.Net.PullRequests.Models.PullRequestDetail pr)
     {
         var reviews = pr.Reviews


### PR DESCRIPTION
## Summary
- `POST /api/repos/{id}/pull-requests/{number}/reviews` Endpoint ergänzt
- `IPullRequestService.CreateReviewAsync` + Implementierung in `PullRequestService`
- Frontend: `createPullRequestReview` in `repository-service.ts`
- Review-Formular im PR-Detail-Panel (nur bei offenen PRs sichtbar)

## UI
- **+ Review**-Button öffnet ein Formular mit optionaler Textarea
- Drei Aktions-Buttons: ✓ Approve, ✗ Request Changes, 💬 Comment
- Validierung: Kommentar Pflicht bei Request Changes / Comment
- Nach erfolgreichem Review: Review-Liste wird aktualisiert, Erfolgsmeldung

## Test plan
- [x] `dotnet build` ohne Fehler
- [x] 86 API-Tests / 60 Core-Tests / 76 AI-Tests grün
- [x] 31 Frontend-Tests grün

Closes #149