### PR TITLE
refactor(api): GitHubControllerBase mit TryResolveOwnerRepo extrahieren (#187)

### DIFF
--- a/src/ghGPT.Api/Controllers/DiscussionsController.cs
+++ b/src/ghGPT.Api/Controllers/DiscussionsController.cs
@@ -8,7 +8,7 @@ namespace ghGPT.Api.Controllers;
 [Route("api/repos/{id}/discussions")]
 public class DiscussionsController(
     IRepositoryService repositoryService,
-    IDiscussionService discussionService) : ControllerBase
+    IDiscussionService discussionService) : GitHubControllerBase(repositoryService)
 {
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<DiscussionItem>>> GetDiscussions(string id, [FromQuery] int limit = 30)
@@ -43,36 +43,6 @@ public class DiscussionsController(
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    private bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
-    {
-        result = default;
-        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
-        if (repo is null)
-        {
-            error = NotFound(new { error = "Repository nicht gefunden." });
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(repo.RemoteUrl))
-        {
-            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
-            return false;
-        }
-
-        try
-        {
-            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
-            result = (parsed.Owner, parsed.Repo);
-            error = null;
-            return true;
-        }
-        catch (InvalidOperationException ex)
-        {
-            error = BadRequest(new { error = ex.Message });
-            return false;
         }
     }
 }

--- a/src/ghGPT.Api/Controllers/GitHubControllerBase.cs
+++ b/src/ghGPT.Api/Controllers/GitHubControllerBase.cs
@@ -1,0 +1,37 @@
+using ghGPT.Core.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ghGPT.Api.Controllers;
+
+public abstract class GitHubControllerBase(IRepositoryService repositoryService) : ControllerBase
+{
+    protected bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
+    {
+        result = default;
+        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
+        if (repo is null)
+        {
+            error = NotFound(new { error = "Repository nicht gefunden." });
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(repo.RemoteUrl))
+        {
+            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
+            return false;
+        }
+
+        try
+        {
+            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
+            result = (parsed.Owner, parsed.Repo);
+            error = null;
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            error = BadRequest(new { error = ex.Message });
+            return false;
+        }
+    }
+}

--- a/src/ghGPT.Api/Controllers/IssuesController.cs
+++ b/src/ghGPT.Api/Controllers/IssuesController.cs
@@ -8,7 +8,7 @@ namespace ghGPT.Api.Controllers;
 [Route("api/repos/{id}/issues")]
 public class IssuesController(
     IRepositoryService repositoryService,
-    IIssueService issueService) : ControllerBase
+    IIssueService issueService) : GitHubControllerBase(repositoryService)
 {
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<IssueListItem>>> GetIssues(
@@ -79,36 +79,6 @@ public class IssuesController(
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    private bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
-    {
-        result = default;
-        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
-        if (repo is null)
-        {
-            error = NotFound(new { error = "Repository nicht gefunden." });
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(repo.RemoteUrl))
-        {
-            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
-            return false;
-        }
-
-        try
-        {
-            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
-            result = (parsed.Owner, parsed.Repo);
-            error = null;
-            return true;
-        }
-        catch (InvalidOperationException ex)
-        {
-            error = BadRequest(new { error = ex.Message });
-            return false;
         }
     }
 }

--- a/src/ghGPT.Api/Controllers/PullRequestsController.cs
+++ b/src/ghGPT.Api/Controllers/PullRequestsController.cs
@@ -8,7 +8,7 @@ namespace ghGPT.Api.Controllers;
 [Route("api/repos/{id}/pull-requests")]
 public class PullRequestsController(
     IRepositoryService repositoryService,
-    IPullRequestService pullRequestService) : ControllerBase
+    IPullRequestService pullRequestService) : GitHubControllerBase(repositoryService)
 {
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<PullRequestListItem>>> GetPullRequests(
@@ -166,36 +166,6 @@ public class PullRequestsController(
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    private bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
-    {
-        result = default;
-        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
-        if (repo is null)
-        {
-            error = NotFound(new { error = "Repository nicht gefunden." });
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(repo.RemoteUrl))
-        {
-            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
-            return false;
-        }
-
-        try
-        {
-            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
-            result = (parsed.Owner, parsed.Repo);
-            error = null;
-            return true;
-        }
-        catch (InvalidOperationException ex)
-        {
-            error = BadRequest(new { error = ex.Message });
-            return false;
         }
     }
 }

--- a/src/ghGPT.Api/Controllers/ReleasesController.cs
+++ b/src/ghGPT.Api/Controllers/ReleasesController.cs
@@ -8,7 +8,7 @@ namespace ghGPT.Api.Controllers;
 [Route("api/repos/{id}/releases")]
 public class ReleasesController(
     IRepositoryService repositoryService,
-    IReleaseService releaseService) : ControllerBase
+    IReleaseService releaseService) : GitHubControllerBase(repositoryService)
 {
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<ReleaseListItem>>> GetReleases(string id, [FromQuery] int limit = 30)
@@ -58,36 +58,6 @@ public class ReleasesController(
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    private bool TryResolveOwnerRepo(string repoId, out (string owner, string repo) result, out ActionResult? error)
-    {
-        result = default;
-        var repo = repositoryService.GetAll().FirstOrDefault(r => r.Id == repoId);
-        if (repo is null)
-        {
-            error = NotFound(new { error = "Repository nicht gefunden." });
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(repo.RemoteUrl))
-        {
-            error = BadRequest(new { error = "Dieses Repository hat keinen GitHub-Remote." });
-            return false;
-        }
-
-        try
-        {
-            var parsed = RemoteUrlParser.Parse(repo.RemoteUrl);
-            result = (parsed.Owner, parsed.Repo);
-            error = null;
-            return true;
-        }
-        catch (InvalidOperationException ex)
-        {
-            error = BadRequest(new { error = ex.Message });
-            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Neue abstrakte Basisklasse `GitHubControllerBase` mit `TryResolveOwnerRepo()`
- `IssuesController`, `PullRequestsController`, `DiscussionsController`, `ReleasesController` erben davon
- ~112 Zeilen duplizierter Code entfernt

## Test plan
- [ ] 86 API-Tests bestanden

Closes #187