### PR TITLE
refactor(api): Globale Exception-Handling Middleware einführen (#188)

### DIFF
--- a/src/ghGPT.Api/Controllers/DiscussionsController.cs
+++ b/src/ghGPT.Api/Controllers/DiscussionsController.cs
@@ -16,15 +16,8 @@ public class DiscussionsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var discussions = await discussionService.GetDiscussionsAsync(ownerRepo.owner, ownerRepo.repo, limit);
-            return Ok(discussions);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var discussions = await discussionService.GetDiscussionsAsync(ownerRepo.owner, ownerRepo.repo, limit);
+        return Ok(discussions);
     }
 
     [HttpPost]
@@ -33,17 +26,10 @@ public class DiscussionsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var discussion = await discussionService.CreateAsync(
-                ownerRepo.owner, ownerRepo.repo,
-                request.Title, request.Body, request.Category ?? "General");
-            return Ok(discussion);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var discussion = await discussionService.CreateAsync(
+            ownerRepo.owner, ownerRepo.repo,
+            request.Title, request.Body, request.Category ?? "General");
+        return Ok(discussion);
     }
 }
 

--- a/src/ghGPT.Api/Controllers/IssuesController.cs
+++ b/src/ghGPT.Api/Controllers/IssuesController.cs
@@ -18,15 +18,8 @@ public class IssuesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var issues = await issueService.GetIssuesAsync(ownerRepo.owner, ownerRepo.repo, state);
-            return Ok(issues);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var issues = await issueService.GetIssuesAsync(ownerRepo.owner, ownerRepo.repo, state);
+        return Ok(issues);
     }
 
     [HttpGet("{number:int}")]
@@ -35,15 +28,8 @@ public class IssuesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var detail = await issueService.GetIssueDetailAsync(ownerRepo.owner, ownerRepo.repo, number);
-            return Ok(detail);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var detail = await issueService.GetIssueDetailAsync(ownerRepo.owner, ownerRepo.repo, number);
+        return Ok(detail);
     }
 
     [HttpPost]
@@ -52,17 +38,10 @@ public class IssuesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var issue = await issueService.CreateAsync(
-                ownerRepo.owner, ownerRepo.repo,
-                request.Title, request.Body, request.Labels);
-            return Ok(issue);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var issue = await issueService.CreateAsync(
+            ownerRepo.owner, ownerRepo.repo,
+            request.Title, request.Body, request.Labels);
+        return Ok(issue);
     }
 
     [HttpPost("{number:int}/comments")]
@@ -71,15 +50,8 @@ public class IssuesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await issueService.AddCommentAsync(ownerRepo.owner, ownerRepo.repo, number, request.Body);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await issueService.AddCommentAsync(ownerRepo.owner, ownerRepo.repo, number, request.Body);
+        return NoContent();
     }
 }
 

--- a/src/ghGPT.Api/Controllers/PullRequestsController.cs
+++ b/src/ghGPT.Api/Controllers/PullRequestsController.cs
@@ -18,15 +18,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var prs = await pullRequestService.GetPullRequestsAsync(ownerRepo.owner, ownerRepo.repo, state);
-            return Ok(prs);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var prs = await pullRequestService.GetPullRequestsAsync(ownerRepo.owner, ownerRepo.repo, state);
+        return Ok(prs);
     }
 
     [HttpGet("{number:int}")]
@@ -35,15 +28,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var detail = await pullRequestService.GetPullRequestDetailAsync(ownerRepo.owner, ownerRepo.repo, number);
-            return Ok(detail);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var detail = await pullRequestService.GetPullRequestDetailAsync(ownerRepo.owner, ownerRepo.repo, number);
+        return Ok(detail);
     }
 
     [HttpPost]
@@ -52,19 +38,12 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var detail = await pullRequestService.CreateAsync(
-                ownerRepo.owner, ownerRepo.repo,
-                request.Title, request.Body,
-                request.HeadBranch, request.BaseBranch,
-                request.Draft);
-            return Ok(detail);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var detail = await pullRequestService.CreateAsync(
+            ownerRepo.owner, ownerRepo.repo,
+            request.Title, request.Body,
+            request.HeadBranch, request.BaseBranch,
+            request.Draft);
+        return Ok(detail);
     }
 
     [HttpPatch("{number:int}")]
@@ -73,15 +52,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.EditAsync(ownerRepo.owner, ownerRepo.repo, number, request.Title, request.Body);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.EditAsync(ownerRepo.owner, ownerRepo.repo, number, request.Title, request.Body);
+        return NoContent();
     }
 
     [HttpPatch("{number:int}/close")]
@@ -90,15 +62,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.CloseAsync(ownerRepo.owner, ownerRepo.repo, number);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.CloseAsync(ownerRepo.owner, ownerRepo.repo, number);
+        return NoContent();
     }
 
     [HttpPatch("{number:int}/reopen")]
@@ -107,15 +72,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.ReopenAsync(ownerRepo.owner, ownerRepo.repo, number);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.ReopenAsync(ownerRepo.owner, ownerRepo.repo, number);
+        return NoContent();
     }
 
     [HttpPost("{number:int}/reviews")]
@@ -124,15 +82,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.CreateReviewAsync(ownerRepo.owner, ownerRepo.repo, number, request.Event, request.Body);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.CreateReviewAsync(ownerRepo.owner, ownerRepo.repo, number, request.Event, request.Body);
+        return NoContent();
     }
 
     [HttpPost("{number:int}/comments")]
@@ -141,15 +92,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.AddCommentAsync(ownerRepo.owner, ownerRepo.repo, number, request.Body);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.AddCommentAsync(ownerRepo.owner, ownerRepo.repo, number, request.Body);
+        return NoContent();
     }
 
     [HttpPost("{number:int}/merge")]
@@ -158,15 +102,8 @@ public class PullRequestsController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            await pullRequestService.MergeAsync(ownerRepo.owner, ownerRepo.repo, number, request.Method, request.CommitTitle, request.CommitBody);
-            return NoContent();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        await pullRequestService.MergeAsync(ownerRepo.owner, ownerRepo.repo, number, request.Method, request.CommitTitle, request.CommitBody);
+        return NoContent();
     }
 }
 

--- a/src/ghGPT.Api/Controllers/ReleasesController.cs
+++ b/src/ghGPT.Api/Controllers/ReleasesController.cs
@@ -16,15 +16,8 @@ public class ReleasesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var releases = await releaseService.GetReleasesAsync(ownerRepo.owner, ownerRepo.repo, limit);
-            return Ok(releases);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var releases = await releaseService.GetReleasesAsync(ownerRepo.owner, ownerRepo.repo, limit);
+        return Ok(releases);
     }
 
     [HttpGet("latest")]
@@ -33,15 +26,8 @@ public class ReleasesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var release = await releaseService.GetLatestAsync(ownerRepo.owner, ownerRepo.repo);
-            return Ok(release);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var release = await releaseService.GetLatestAsync(ownerRepo.owner, ownerRepo.repo);
+        return Ok(release);
     }
 
     [HttpGet("{tag}")]
@@ -50,14 +36,7 @@ public class ReleasesController(
         if (!TryResolveOwnerRepo(id, out var ownerRepo, out var error))
             return error!;
 
-        try
-        {
-            var release = await releaseService.GetByTagAsync(ownerRepo.owner, ownerRepo.repo, tag);
-            return Ok(release);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var release = await releaseService.GetByTagAsync(ownerRepo.owner, ownerRepo.repo, tag);
+        return Ok(release);
     }
 }

--- a/src/ghGPT.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/ghGPT.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -11,16 +11,16 @@ public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<Exception
         {
             await next(context);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (!context.Response.HasStarted)
         {
             await WriteErrorAsync(context, HttpStatusCode.BadRequest, ex.Message);
         }
-        catch (HttpRequestException ex)
+        catch (HttpRequestException ex) when (!context.Response.HasStarted)
         {
             logger.LogWarning(ex, "Externe HTTP-Anfrage fehlgeschlagen.");
             await WriteErrorAsync(context, HttpStatusCode.ServiceUnavailable, "Externer Dienst ist nicht erreichbar.");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!context.Response.HasStarted)
         {
             logger.LogError(ex, "Unbehandelter Fehler.");
             await WriteErrorAsync(context, HttpStatusCode.InternalServerError, "Ein unerwarteter Fehler ist aufgetreten.");

--- a/src/ghGPT.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/ghGPT.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Text.Json;
+
+namespace ghGPT.Api.Middleware;
+
+public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (InvalidOperationException ex)
+        {
+            await WriteErrorAsync(context, HttpStatusCode.BadRequest, ex.Message);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogWarning(ex, "Externe HTTP-Anfrage fehlgeschlagen.");
+            await WriteErrorAsync(context, HttpStatusCode.ServiceUnavailable, "Externer Dienst ist nicht erreichbar.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unbehandelter Fehler.");
+            await WriteErrorAsync(context, HttpStatusCode.InternalServerError, "Ein unerwarteter Fehler ist aufgetreten.");
+        }
+    }
+
+    private static async Task WriteErrorAsync(HttpContext context, HttpStatusCode statusCode, string message)
+    {
+        context.Response.StatusCode = (int)statusCode;
+        context.Response.ContentType = "application/json";
+        var body = JsonSerializer.Serialize(new { error = message });
+        await context.Response.WriteAsync(body);
+    }
+}

--- a/src/ghGPT.Api/Program.cs
+++ b/src/ghGPT.Api/Program.cs
@@ -1,5 +1,6 @@
 using ghGPT.Ai;
 using ghGPT.Api.Hubs;
+using ghGPT.Api.Middleware;
 using ghGPT.Core.Repositories;
 using ghGPT.Infrastructure;
 
@@ -17,6 +18,8 @@ var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
+
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.UseDefaultFiles();
 app.UseStaticFiles();


### PR DESCRIPTION
## Summary

- Neue `ExceptionHandlingMiddleware` in `src/ghGPT.Api/Middleware/`
  - `InvalidOperationException` → 400 Bad Request
  - `HttpRequestException` → 503 Service Unavailable
  - Unbekannte Exceptions → 500 Internal Server Error
- In `Program.cs` registriert
- Try/catch-Blöcke aus `IssuesController`, `PullRequestsController`, `DiscussionsController`, `ReleasesController` entfernt (~86 Zeilen)
- Controller mit kontext-spezifischer Fehlerbehandlung (NotFound, Conflict, SignalR-Events) bleiben unverändert

## Scope-Entscheidung

`ChangesController`, `BranchesController`, `StashController`, `RepositoriesController` behalten ihre try/catch-Blöcke, da sie kontextabhängige Status Codes (404, 409) zurückgeben oder Fehler zusätzlich über SignalR melden.

## Test plan
- [ ] 301 Tests bestanden (86 API + 60 Core + 76 AI + 48 Infrastructure + 31 Frontend)

Closes #188