### PR TITLE
refactor(frontend): State-Naming in View-Komponenten vereinheitlichen (#190)

### DIFF
--- a/src/ghGPT.Frontend/src/components/history-view.ts
+++ b/src/ghGPT.Frontend/src/components/history-view.ts
@@ -22,10 +22,10 @@ export class HistoryView extends AppElement {
   @state() private entries: CommitListItem[] = [];
   @state() private branchName = '';
   @state() private hasMore = false;
-  @state() private loadingList = false;
+  @state() private loading = false;
   @state() private loadingDetail = false;
-  @state() private listError = '';
-  @state() private detailError = '';
+  @state() private listError: string | null = null;
+  @state() private detailError: string | null = null;
   @state() private selectedCommitSha = '';
   @state() private selectedCommit: CommitDetail | null = null;
   @state() private selectedFileIndex = 0;
@@ -50,8 +50,8 @@ export class HistoryView extends AppElement {
     this.entries = [];
     this.branchName = this.branch;
     this.hasMore = false;
-    this.listError = '';
-    this.detailError = '';
+    this.listError = null;
+    this.detailError = null;
     this.selectedCommit = null;
     this.selectedCommitSha = '';
     this.selectedFileIndex = 0;
@@ -114,9 +114,9 @@ export class HistoryView extends AppElement {
   }
 
   private async loadMoreCommits(reset = false) {
-    if (!this.repoId || this.loadingList || (!reset && !this.hasMore && this.entries.length > 0)) return;
+    if (!this.repoId || this.loading || (!reset && !this.hasMore && this.entries.length > 0)) return;
 
-    this.loadingList = true;
+    this.loading = true;
     try {
       const result = await repositoryService.getCommits(
         this.repoId,
@@ -128,7 +128,7 @@ export class HistoryView extends AppElement {
       this.branchName = result.branch;
       this.hasMore = result.hasMore;
       this.entries = reset ? result.commits : [...this.entries, ...result.commits];
-      this.listError = '';
+      this.listError = null;
 
       const selectedStillExists = this.entries.some(entry => entry.sha === this.selectedCommitSha);
       if (this.entries.length > 0 && (!this.selectedCommitSha || !selectedStillExists)) {
@@ -137,7 +137,7 @@ export class HistoryView extends AppElement {
     } catch (e: unknown) {
       this.listError = e instanceof Error ? e.message : 'Fehler beim Laden der Commits';
     } finally {
-      this.loadingList = false;
+      this.loading = false;
     }
   }
 
@@ -325,7 +325,7 @@ export class HistoryView extends AppElement {
             `}
 
         <div data-testid="footer-hint" class="px-3.5 py-2 border-t border-cat-border text-[0.72rem] text-[#8f96b3] shrink-0">
-          ${this.loadingList ? 'Lade weitere Commits…' : this.hasMore ? 'Weitere Commits werden beim Scrollen geladen.' : `${this.entries.length} Commits geladen`}
+          ${this.loading ? 'Lade weitere Commits…' : this.hasMore ? 'Weitere Commits werden beim Scrollen geladen.' : `${this.entries.length} Commits geladen`}
         </div>
       </section>
 

--- a/src/ghGPT.Frontend/src/components/history-view.ts
+++ b/src/ghGPT.Frontend/src/components/history-view.ts
@@ -145,7 +145,7 @@ export class HistoryView extends AppElement {
     this.selectedCommitSha = sha;
     this.selectedCommit = null;
     this.selectedFileIndex = 0;
-    this.detailError = '';
+    this.detailError = null;
     this.loadingDetail = true;
 
     try {

--- a/src/ghGPT.Frontend/src/components/stashes-view.ts
+++ b/src/ghGPT.Frontend/src/components/stashes-view.ts
@@ -10,7 +10,7 @@ export class StashesView extends AppElement {
 
   @state() private stashes: StashEntry[] = [];
   @state() private loading = false;
-  @state() private error = '';
+  @state() private error: string | null = null;
   @state() private selectedStash: StashEntry | null = null;
   @state() private stashFiles: CommitFileChange[] = [];
   @state() private loadingDiff = false;
@@ -22,7 +22,7 @@ export class StashesView extends AppElement {
 
   private async load() {
     this.loading = true;
-    this.error = '';
+    this.error = null;
     try {
       this.stashes = await repositoryService.getStashes(this.repoId);
       if (this.selectedStash !== null) {
@@ -56,7 +56,7 @@ export class StashesView extends AppElement {
   }
 
   private async pop(index: number) {
-    this.error = '';
+    this.error = null;
     try {
       await repositoryService.popStash(this.repoId, index);
       if (this.selectedStash?.index === index) {
@@ -72,7 +72,7 @@ export class StashesView extends AppElement {
 
   private async drop(index: number) {
     if (!confirm(`Stash #${index} wirklich verwerfen?`)) return;
-    this.error = '';
+    this.error = null;
     try {
       await repositoryService.dropStash(this.repoId, index);
       if (this.selectedStash?.index === index) {


### PR DESCRIPTION
## Summary

Naming-Inkonsistenzen in zwei View-Komponenten behoben:

**stashes-view.ts**
- `error = ''` → `error: string | null = null` (konsistent mit allen anderen Views)
- Alle Zuweisungen auf `null` umgestellt

**history-view.ts**
- `listError = ''` → `listError: string | null = null`
- `detailError = ''` → `detailError: string | null = null`
- `loadingList` → `loading` (konsistent mit issues-view, pull-requests-view, etc.)

## Entscheidung gegen AppElement-Mixin

Ein gemeinsames Base-Mixin für `loading`/`error`/`actionBusy`/`actionError` wäre overengineered: Die Views brauchen unterschiedliche Subsets dieser Properties (manche haben `loadingDetail`, manche `actionBusy`, manche beides), und das Hinzufügen zu `AppElement` würde unerwünschte Kopplung einführen.

## Test plan
- [ ] Build erfolgreich
- [ ] 31 Frontend-Tests bestanden

Closes #190