### PR TITLE
test(core): OldFilePath-Coverage in FileStatusEntryTests (#201)

### DIFF
--- a/tests/ghGPT.Core.Tests/FileStatusEntryTests.cs
+++ b/tests/ghGPT.Core.Tests/FileStatusEntryTests.cs
@@ -28,6 +28,27 @@ public class FileStatusEntryTests
     }
 
     [Fact]
+    public void FileStatusEntry_OldFilePath_DefaultsToNull()
+    {
+        var entry = new FileStatusEntry();
+
+        Assert.Null(entry.OldFilePath);
+    }
+
+    [Fact]
+    public void FileStatusEntry_OldFilePath_CanBeSet()
+    {
+        var entry = new FileStatusEntry
+        {
+            FilePath = "DOCS.md",
+            OldFilePath = "README.md",
+            Status = "Renamed"
+        };
+
+        Assert.Equal("README.md", entry.OldFilePath);
+    }
+
+    [Fact]
     public void FileStatusEntry_IsStaged_ReflectsStagingState()
     {
         var staged = new FileStatusEntry { FilePath = "a.cs", Status = "Modified", IsStaged = true };


### PR DESCRIPTION
## Summary
- Zwei Tests ergänzt: `OldFilePath_DefaultsToNull` und `OldFilePath_CanBeSet`
- Konsistent mit dem bestehenden Stil der Datei

## Test plan
- [x] `dotnet test tests/ghGPT.Core.Tests` — alle Tests grün (10/10 in FileStatusEntry, 62/62 Core insgesamt)

Closes #201